### PR TITLE
Proto API fixes: gen type and underay.vrf should be plural

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway_config"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -22,5 +22,5 @@ tower = "0.5.2"
 tokio-stream = { version = "0.1", features = ["net"] }
 
 [build-dependencies]
-tonic-build = {version = "0.13", optional = true }
+tonic-build = { version = "0.13", optional = true }
 protoc-bin-vendored = { version = "3.1.0", optional = true }

--- a/pkg/dataplane/dataplane.pb.go
+++ b/pkg/dataplane/dataplane.pb.go
@@ -552,7 +552,7 @@ func (*GetConfigGenerationRequest) Descriptor() ([]byte, []int) {
 
 type GetConfigGenerationResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Generation    uint64                 `protobuf:"varint,1,opt,name=generation,proto3" json:"generation,omitempty"`
+	Generation    int64                  `protobuf:"varint,1,opt,name=generation,proto3" json:"generation,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -587,7 +587,7 @@ func (*GetConfigGenerationResponse) Descriptor() ([]byte, []int) {
 	return file_proto_dataplane_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *GetConfigGenerationResponse) GetGeneration() uint64 {
+func (x *GetConfigGenerationResponse) GetGeneration() int64 {
 	if x != nil {
 		return x.Generation
 	}
@@ -1921,7 +1921,7 @@ func (x *Device) GetLoglevel() LogLevel {
 // Complete Gateway config options
 type GatewayConfig struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Generation    uint64                 `protobuf:"varint,1,opt,name=generation,proto3" json:"generation,omitempty"`
+	Generation    int64                  `protobuf:"varint,1,opt,name=generation,proto3" json:"generation,omitempty"`
 	Device        *Device                `protobuf:"bytes,2,opt,name=device,proto3" json:"device,omitempty"`
 	Underlay      *Underlay              `protobuf:"bytes,3,opt,name=underlay,proto3" json:"underlay,omitempty"`
 	Overlay       *Overlay               `protobuf:"bytes,4,opt,name=overlay,proto3" json:"overlay,omitempty"`
@@ -1959,7 +1959,7 @@ func (*GatewayConfig) Descriptor() ([]byte, []int) {
 	return file_proto_dataplane_proto_rawDescGZIP(), []int{26}
 }
 
-func (x *GatewayConfig) GetGeneration() uint64 {
+func (x *GatewayConfig) GetGeneration() int64 {
 	if x != nil {
 		return x.Generation
 	}
@@ -2001,7 +2001,7 @@ const file_proto_dataplane_proto_rawDesc = "" +
 	"\x1aGetConfigGenerationRequest\"=\n" +
 	"\x1bGetConfigGenerationResponse\x12\x1e\n" +
 	"\n" +
-	"generation\x18\x01 \x01(\x04R\n" +
+	"generation\x18\x01 \x01(\x03R\n" +
 	"generation\"\xb1\x01\n" +
 	"\rOspfInterface\x12\x18\n" +
 	"\apassive\x18\x01 \x01(\bR\apassive\x12\x12\n" +
@@ -2115,7 +2115,7 @@ const file_proto_dataplane_proto_rawDesc = "" +
 	"\bloglevel\x18\x05 \x01(\x0e2\x10.config.LogLevelR\bloglevel\"\xb0\x01\n" +
 	"\rGatewayConfig\x12\x1e\n" +
 	"\n" +
-	"generation\x18\x01 \x01(\x04R\n" +
+	"generation\x18\x01 \x01(\x03R\n" +
 	"generation\x12&\n" +
 	"\x06device\x18\x02 \x01(\v2\x0e.config.DeviceR\x06device\x12,\n" +
 	"\bunderlay\x18\x03 \x01(\v2\x10.config.UnderlayR\bunderlay\x12)\n" +

--- a/pkg/dataplane/dataplane.pb.go
+++ b/pkg/dataplane/dataplane.pb.go
@@ -1709,7 +1709,7 @@ func (x *VRF) GetOspf() *OspfConfig {
 // List of all non-VPC VRFs
 type Underlay struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Vrf           []*VRF                 `protobuf:"bytes,1,rep,name=vrf,proto3" json:"vrf,omitempty"`
+	Vrfs          []*VRF                 `protobuf:"bytes,1,rep,name=vrfs,proto3" json:"vrfs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1744,9 +1744,9 @@ func (*Underlay) Descriptor() ([]byte, []int) {
 	return file_proto_dataplane_proto_rawDescGZIP(), []int{22}
 }
 
-func (x *Underlay) GetVrf() []*VRF {
+func (x *Underlay) GetVrfs() []*VRF {
 	if x != nil {
-		return x.Vrf
+		return x.Vrfs
 	}
 	return nil
 }
@@ -2099,9 +2099,9 @@ const file_proto_dataplane_proto_rawDesc = "" +
 	"\x06router\x18\x03 \x01(\v2\x14.config.RouterConfigH\x00R\x06router\x88\x01\x01\x12+\n" +
 	"\x04ospf\x18\x04 \x01(\v2\x12.config.OspfConfigH\x01R\x04ospf\x88\x01\x01B\t\n" +
 	"\a_routerB\a\n" +
-	"\x05_ospf\")\n" +
-	"\bUnderlay\x12\x1d\n" +
-	"\x03vrf\x18\x01 \x03(\v2\v.config.VRFR\x03vrf\"<\n" +
+	"\x05_ospf\"+\n" +
+	"\bUnderlay\x12\x1f\n" +
+	"\x04vrfs\x18\x01 \x03(\v2\v.config.VRFR\x04vrfs\"<\n" +
 	"\x05Ports\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
 	"\vsystem_name\x18\x02 \x01(\tR\n" +
@@ -2232,7 +2232,7 @@ var file_proto_dataplane_proto_depIdxs = []int32{
 	14, // 19: config.VRF.interfaces:type_name -> config.Interface
 	27, // 20: config.VRF.router:type_name -> config.RouterConfig
 	13, // 21: config.VRF.ospf:type_name -> config.OspfConfig
-	28, // 22: config.Underlay.vrf:type_name -> config.VRF
+	28, // 22: config.Underlay.vrfs:type_name -> config.VRF
 	6,  // 23: config.Device.driver:type_name -> config.PacketDriver
 	31, // 24: config.Device.eal:type_name -> config.Eal
 	30, // 25: config.Device.ports:type_name -> config.Ports

--- a/pkg/dataplane/dataplane_test.go
+++ b/pkg/dataplane/dataplane_test.go
@@ -56,13 +56,13 @@ func TestDataplaneClient(t *testing.T) {
 		resp, err := client.GetConfig(ctx, &dataplane.GetConfigRequest{}, grpc.WaitForReady(true))
 		require.NoError(t, err, "failed to get config")
 		require.Equal(t, codes.OK, status.Code(err), "unexpected error code for get config")
-		require.Equal(t, uint64(42), resp.Generation, "unexpected response for get config")
+		require.Equal(t, int64(42), resp.Generation, "unexpected response for get config")
 	}
 
 	{
 		resp, err := client.GetConfigGeneration(ctx, &dataplane.GetConfigGenerationRequest{}, grpc.WaitForReady(true))
 		require.NoError(t, err, "failed to get config generation")
 		require.Equal(t, codes.OK, status.Code(err), "unexpected error code for get config generation")
-		require.Equal(t, uint64(42), resp.Generation, "unexpected response for get config generation")
+		require.Equal(t, int64(42), resp.Generation, "unexpected response for get config generation")
 	}
 }

--- a/pkg/protoyaml/encode_test.go
+++ b/pkg/protoyaml/encode_test.go
@@ -22,7 +22,7 @@ func TestMarshalUnmarshalYAML(t *testing.T) {
 			input: &dataplane.GatewayConfig{
 				Generation: 42,
 				Underlay: &dataplane.Underlay{
-					Vrf: []*dataplane.VRF{
+					Vrfs: []*dataplane.VRF{
 						{
 							Name: "vrf1",
 							Interfaces: []*dataplane.Interface{
@@ -68,19 +68,19 @@ func TestUnmarshal(t *testing.T) {
 			input: `
 generation: 42
 underlay:
-  vrf:
+  vrfs:
   - interfaces:
     - name: eth0
       type: IF_TYPE_ETHERNET
     name: vrf1
 `,
 			check: func(t *testing.T, actual *dataplane.GatewayConfig) {
-				require.Equal(t, uint64(42), actual.Generation)
-				require.Len(t, actual.Underlay.Vrf, 1)
-				require.Equal(t, "vrf1", actual.Underlay.Vrf[0].Name)
-				require.Len(t, actual.Underlay.Vrf[0].Interfaces, 1)
-				require.Equal(t, "eth0", actual.Underlay.Vrf[0].Interfaces[0].Name)
-				require.Equal(t, dataplane.IfType_IF_TYPE_ETHERNET, actual.Underlay.Vrf[0].Interfaces[0].Type)
+				require.Equal(t, int64(42), actual.Generation)
+				require.Len(t, actual.Underlay.Vrfs, 1)
+				require.Equal(t, "vrf1", actual.Underlay.Vrfs[0].Name)
+				require.Len(t, actual.Underlay.Vrfs[0].Interfaces, 1)
+				require.Equal(t, "eth0", actual.Underlay.Vrfs[0].Interfaces[0].Name)
+				require.Equal(t, dataplane.IfType_IF_TYPE_ETHERNET, actual.Underlay.Vrfs[0].Interfaces[0].Type)
 			},
 		},
 		{
@@ -88,18 +88,18 @@ underlay:
 			input: `
 generation: 42
 underlay:
-  vrf:
+  vrfs:
   - interfaces:
     - name: eth0
     name: vrf1
 `,
 			check: func(t *testing.T, actual *dataplane.GatewayConfig) {
-				require.Equal(t, uint64(42), actual.Generation)
-				require.Len(t, actual.Underlay.Vrf, 1)
-				require.Equal(t, "vrf1", actual.Underlay.Vrf[0].Name)
-				require.Len(t, actual.Underlay.Vrf[0].Interfaces, 1)
-				require.Equal(t, "eth0", actual.Underlay.Vrf[0].Interfaces[0].Name)
-				require.Equal(t, dataplane.IfType_IF_TYPE_ETHERNET, actual.Underlay.Vrf[0].Interfaces[0].Type)
+				require.Equal(t, int64(42), actual.Generation)
+				require.Len(t, actual.Underlay.Vrfs, 1)
+				require.Equal(t, "vrf1", actual.Underlay.Vrfs[0].Name)
+				require.Len(t, actual.Underlay.Vrfs[0].Interfaces, 1)
+				require.Equal(t, "eth0", actual.Underlay.Vrfs[0].Interfaces[0].Name)
+				require.Equal(t, dataplane.IfType_IF_TYPE_ETHERNET, actual.Underlay.Vrfs[0].Interfaces[0].Type)
 			},
 		},
 		{
@@ -107,19 +107,19 @@ underlay:
 			input: `
 generation: 42
 underlay:
-  vrf:
+  vrfs:
   - interfaces:
     - name: eth0
       type: IF_TYPE_VLAN
     name: vrf1
 `,
 			check: func(t *testing.T, actual *dataplane.GatewayConfig) {
-				require.Equal(t, uint64(42), actual.Generation)
-				require.Len(t, actual.Underlay.Vrf, 1)
-				require.Equal(t, "vrf1", actual.Underlay.Vrf[0].Name)
-				require.Len(t, actual.Underlay.Vrf[0].Interfaces, 1)
-				require.Equal(t, "eth0", actual.Underlay.Vrf[0].Interfaces[0].Name)
-				require.Equal(t, dataplane.IfType_IF_TYPE_VLAN, actual.Underlay.Vrf[0].Interfaces[0].Type)
+				require.Equal(t, int64(42), actual.Generation)
+				require.Len(t, actual.Underlay.Vrfs, 1)
+				require.Equal(t, "vrf1", actual.Underlay.Vrfs[0].Name)
+				require.Len(t, actual.Underlay.Vrfs[0].Interfaces, 1)
+				require.Equal(t, "eth0", actual.Underlay.Vrfs[0].Interfaces[0].Name)
+				require.Equal(t, dataplane.IfType_IF_TYPE_VLAN, actual.Underlay.Vrfs[0].Interfaces[0].Type)
 			},
 		},
 		{
@@ -128,7 +128,7 @@ underlay:
 generation: "42"
 `,
 			check: func(t *testing.T, actual *dataplane.GatewayConfig) {
-				require.Equal(t, uint64(42), actual.Generation)
+				require.Equal(t, int64(42), actual.Generation)
 			},
 		},
 	} {

--- a/proto/dataplane.proto
+++ b/proto/dataplane.proto
@@ -211,7 +211,7 @@ message VRF {
 
 /* List of all non-VPC VRFs */
 message Underlay {
-  repeated VRF vrf = 1;
+  repeated VRF vrfs = 1;
 }
 
 /* ================ */

--- a/proto/dataplane.proto
+++ b/proto/dataplane.proto
@@ -36,7 +36,7 @@ message GetConfigGenerationRequest {
 }
 
 message GetConfigGenerationResponse {
-  uint64 generation = 1;
+  int64 generation = 1;
 }
 
 /* ================================================ */
@@ -263,9 +263,8 @@ message Device {
 
 /* Complete Gateway config options */
 message GatewayConfig {
-  uint64 generation = 1;
+  int64 generation = 1;
   Device device = 2;
   Underlay underlay = 3;
   Overlay overlay = 4;
 }
-

--- a/src/generated/config.rs
+++ b/src/generated/config.rs
@@ -250,7 +250,7 @@ pub struct Vrf {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Underlay {
     #[prost(message, repeated, tag = "1")]
-    pub vrf: ::prost::alloc::vec::Vec<Vrf>,
+    pub vrfs: ::prost::alloc::vec::Vec<Vrf>,
 }
 /// Defines physical or system-level device
 #[derive(::serde::Deserialize, ::serde::Serialize)]

--- a/src/generated/config.rs
+++ b/src/generated/config.rs
@@ -25,8 +25,8 @@ pub struct GetConfigGenerationRequest {}
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct GetConfigGenerationResponse {
-    #[prost(uint64, tag = "1")]
-    pub generation: u64,
+    #[prost(int64, tag = "1")]
+    pub generation: i64,
 }
 /// OSPF Interface configuration
 #[derive(::serde::Deserialize, ::serde::Serialize)]
@@ -290,8 +290,8 @@ pub struct Device {
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GatewayConfig {
-    #[prost(uint64, tag = "1")]
-    pub generation: u64,
+    #[prost(int64, tag = "1")]
+    pub generation: i64,
     #[prost(message, optional, tag = "2")]
     pub device: ::core::option::Option<Device>,
     #[prost(message, optional, tag = "3")]


### PR DESCRIPTION
We're directly using K8s resources Generation as a "version" (and it's int64, not uint64) for the configuration that is managed by the agent and passed to the dataplane so its type should be aligned.