### PR TITLE
Bolero generators for Rust gRPC generated code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.86.0
           components: rustfmt clippy
 
       - name: Lint and generate code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+          components: rustfmt clippy
 
       - name: Lint and generate code
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.cursor
+.vscode
 .DS_Store
 *kubeconfig.yaml
 lcov.info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "protoc-bin-vendored",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -1125,6 +1126,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "bolero",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,7 +46,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -128,10 +134,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bolero"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e913ed74716cd68dc5be41c702327b1cc4ffc8f0b55945ae46fb015777007eb"
+dependencies = [
+ "bolero-afl",
+ "bolero-engine",
+ "bolero-generator",
+ "bolero-honggfuzz",
+ "bolero-kani",
+ "bolero-libfuzzer",
+ "cfg-if",
+ "rand",
+]
+
+[[package]]
+name = "bolero-afl"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bf4cbd0bacf9356d3c7e5d9d088480f2076ba3c595c15ee9a6a378cdd7b297"
+dependencies = [
+ "bolero-engine",
+ "cc",
+]
+
+[[package]]
+name = "bolero-engine"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cae8c41807b046bb7005f52fa60c8f67787c1bf272242f0b84224853e04ceb"
+dependencies = [
+ "anyhow",
+ "bolero-generator",
+ "lazy_static",
+ "pretty-hex",
+ "rand",
+ "rand_xoshiro",
+]
+
+[[package]]
+name = "bolero-generator"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3ac7405f187921256faa515fa05ae02521103582a9d938410cefabe3a9a172"
+dependencies = [
+ "arbitrary",
+ "bolero-generator-derive",
+ "either",
+ "getrandom",
+ "rand_core",
+ "rand_xoshiro",
+]
+
+[[package]]
+name = "bolero-generator-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c56c2f8c1c0707d678bebb36168cfd523c45927bb8d9cb7567d3578fa428cbd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "bolero-honggfuzz"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a118ef27295eddefadc6a99728ee698d1b18d2e80dc4777d21bee3385096ffd"
+dependencies = [
+ "bolero-engine",
+]
+
+[[package]]
+name = "bolero-kani"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852ea5784a9f3e68bfd302ca80b8b863bce140593eb5770fee6ab110899c28fc"
+dependencies = [
+ "bolero-engine",
+]
+
+[[package]]
+name = "bolero-libfuzzer"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "858dc57c11725c52662501fa79fdbc6f7050339a05ca1bf1e587add0fed40d62"
+dependencies = [
+ "bolero-engine",
+ "cc",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -235,7 +344,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -273,6 +382,7 @@ name = "gateway_config"
 version = "0.2.2"
 dependencies = [
  "async-trait",
+ "bolero",
  "futures",
  "prost",
  "protoc-bin-vendored",
@@ -460,6 +570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,7 +718,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -618,13 +734,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "pretty-hex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
@@ -662,7 +803,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.100",
  "tempfile",
 ]
 
@@ -676,7 +817,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -759,6 +900,44 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -852,7 +1031,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -866,6 +1045,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -899,6 +1084,17 @@ checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -957,7 +1153,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -982,6 +1178,23 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1024,7 +1237,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1077,7 +1290,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1208,10 +1421,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,15 @@ license = "Apache-2.0"
 
 [features]
 default = []
+bolero = ["dep:bolero"]
 regenerate = ["dep:tonic-build", "dep:protoc-bin-vendored"]
 
 [dependencies]
+bolero = { version = "0.13.3", features = [
+    "alloc",
+    "arbitrary",
+    "std",
+], optional = true }
 tonic = "0.13"
 prost = "0.13.5"
 tokio = { version = "1.34", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway_config"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 tower = "0.5.2"
+thiserror = { version = "2.0.12", features = ["std"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,16 @@
 // Copyright 2025 Hedgehog
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "regenerate")]
+fn add_type_generators(bld: tonic_build::Builder, types: &[&str]) -> tonic_build::Builder {
+    types.iter().fold(bld, |bld, t| {
+        bld.type_attribute(
+            t,
+            "#[cfg_attr(feature = \"bolero\", derive(::bolero::TypeGenerator))]",
+        )
+    })
+}
+
 fn main() {
     #[cfg(feature = "regenerate")]
     {
@@ -11,7 +21,22 @@ fn main() {
 
         let proto = "proto/dataplane.proto";
 
-        let res = tonic_build::configure()
+        let bld = tonic_build::configure();
+        let bld = add_type_generators(
+            bld,
+            &[
+                "BgpAddressFamilyIPv4",
+                "BgpAddressFamilyIPv6",
+                "BgpAddressFamilyL2vpnEvpn",
+                "BgpAF",
+                "IfType",
+                "IfRole",
+                "LogLevel",
+                "OspfNetworkType",
+                "PacketDriver",
+            ],
+        );
+        let res = bld
             .type_attribute(".", "#[derive(::serde::Deserialize, ::serde::Serialize)]")
             .build_server(true)
             .build_client(true)

--- a/justfile
+++ b/justfile
@@ -13,8 +13,12 @@ _gotools:
   go fmt ./...
   go vet {{go_flags}} ./...
 
+_rusttools: 
+  cargo fmt
+  cargo clippy --features bolero --all-targets -- -D warnings
+
 # Run linters against code (incl. license headers)
-lint: _license_headers _gotools
+lint: _license_headers _gotools _rusttools
 
 _path := `echo $PATH`
 gen: _protoc _protoc_gen_go _protoc_gen_go_grpc && lint
@@ -28,7 +32,7 @@ test: gen
 go_build := "go build " + go_flags
 go_linux_build := "GOOS=linux GOARCH=amd64 " + go_build
 
-build: _license_headers _gotools gen && version
+build: _license_headers _gotools _rusttools gen && version
   {{go_linux_build}} -o ./bin/gwtestctl ./cmd/gwtestctl
 
 oci_repo := "127.0.0.1:30000"

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ gen: _protoc _protoc_gen_go _protoc_gen_go_grpc && lint
 
 test: gen
   go test -v ./...
-  cargo test -- --nocapture
+  cargo test --features bolero -- --nocapture
 
 go_build := "go build " + go_flags
 go_linux_build := "GOOS=linux GOARCH=amd64 " + go_build

--- a/src/bolero/bgp.rs
+++ b/src/bolero/bgp.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use crate::bolero::support::{
+    CidrString, IpAddrString, Ipv4AddrString, K8sObjectNameString, LinuxIfName, choose,
+};
+use crate::config::{
+    BgpAddressFamilyIPv4, BgpAddressFamilyIPv6, BgpAddressFamilyL2vpnEvpn, BgpAf, BgpNeighbor,
+    BgpNeighborUpdateSource, RouteMap, RouterConfig, bgp_neighbor_update_source,
+};
+use bolero::{Driver, TypeGenerator};
+use std::ops::Bound;
+
+#[derive(Clone, Copy, PartialEq, TypeGenerator)]
+enum BgpNeighborUpdateSourceType {
+    Address,
+    Interface,
+}
+
+impl TypeGenerator for bgp_neighbor_update_source::Source {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let source: BgpNeighborUpdateSourceType = d.produce()?;
+
+        match source {
+            BgpNeighborUpdateSourceType::Address => Some(
+                bgp_neighbor_update_source::Source::Address(d.produce::<IpAddrString>()?.0),
+            ),
+            BgpNeighborUpdateSourceType::Interface => Some(
+                bgp_neighbor_update_source::Source::Interface(d.produce::<LinuxIfName>()?.0),
+            ),
+        }
+    }
+}
+
+impl TypeGenerator for BgpNeighborUpdateSource {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(BgpNeighborUpdateSource {
+            source: Some(d.produce::<bgp_neighbor_update_source::Source>())?,
+        })
+    }
+}
+
+impl TypeGenerator for BgpNeighbor {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let naf = d.gen_usize(Bound::Included(&0), Bound::Included(&2))?;
+        let nnetworks = d.gen_usize(Bound::Included(&0), Bound::Included(&10))?;
+        let af_activate_set: std::collections::HashSet<_> = (0..naf)
+            .map(|_| d.produce::<BgpAf>())
+            .collect::<Option<std::collections::HashSet<_>>>()?;
+        Some(BgpNeighbor {
+            address: d.produce::<IpAddrString>()?.0,
+            remote_asn: d.produce::<u32>()?.to_string(),
+            #[allow(clippy::redundant_closure_for_method_calls)]
+            af_activate: af_activate_set.into_iter().map(|af| af.into()).collect(),
+            update_source: Some(d.produce::<BgpNeighborUpdateSource>()?),
+            networks: (0..nnetworks)
+                .map(|_| d.produce::<CidrString>().map(|cidr| cidr.0))
+                .collect::<Option<Vec<_>>>()?,
+        })
+    }
+}
+
+// TODO: Implement this properly when dataplane supports route maps
+impl TypeGenerator for RouteMap {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let nprefixes = d.gen_usize(Bound::Included(&0), Bound::Included(&10))?;
+        let match_prefix_lists = (0..nprefixes)
+            .map(|_| d.produce::<CidrString>().map(|prefix| prefix.0))
+            .collect::<Option<Vec<_>>>()?;
+        Some(RouteMap {
+            name: d.produce::<K8sObjectNameString>()?.0,
+            match_prefix_lists,
+            action: d.produce::<String>()?,
+            sequence: d.produce::<u32>()?,
+        })
+    }
+}
+
+impl TypeGenerator for RouterConfig {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let nneighbors = d.gen_usize(Bound::Included(&0), Bound::Included(&10))?;
+        let ipv4_family = d.produce::<BgpAddressFamilyIPv4>()?;
+        let ipv6_family = d.produce::<BgpAddressFamilyIPv6>()?;
+        let l2vpn_evpn = d.produce::<BgpAddressFamilyL2vpnEvpn>()?;
+        let ipv4_unicast = choose(d, &[Some(ipv4_family), None])?;
+        let ipv6_unicast = choose(d, &[Some(ipv6_family), None])?;
+        let l2vpn_evpn = choose(d, &[Some(l2vpn_evpn), None])?;
+        Some(RouterConfig {
+            asn: d.produce::<u32>()?.to_string(),
+            router_id: d.produce::<Ipv4AddrString>()?.0, // TODO: Add ipv6 support when dataplane supports it
+            neighbors: (0..nneighbors)
+                .map(|_| d.produce::<BgpNeighbor>())
+                .collect::<Option<Vec<_>>>()?,
+            ipv4_unicast,
+            ipv6_unicast,
+            l2vpn_evpn,
+            route_maps: vec![], // TODO: Add route maps when dataplane supports it
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_bgp_neighbor_update_source() {
+        bolero::check!()
+            .with_type::<BgpNeighborUpdateSource>()
+            .for_each(|bgp_neighbor_update_source| {
+                assert!(bgp_neighbor_update_source.source.is_some());
+            });
+    }
+
+    #[test]
+    fn test_bgp_neighbor() {
+        let mut some_nets = false;
+        let mut some_afs = false;
+        bolero::check!()
+            .with_type::<BgpNeighbor>()
+            .for_each(|bgp_neighbor| {
+                assert!(bgp_neighbor.remote_asn.parse::<u32>().is_ok());
+                if !bgp_neighbor.networks.is_empty() {
+                    some_nets = true;
+                }
+                if !bgp_neighbor.af_activate.is_empty() {
+                    some_afs = true;
+                }
+            });
+        assert!(some_nets);
+        assert!(some_afs);
+    }
+
+    #[test]
+    fn test_router_config() {
+        bolero::check!()
+            .with_type::<RouterConfig>()
+            .for_each(|router_config| {
+                assert!(router_config.asn.parse::<u32>().is_ok());
+            });
+    }
+}

--- a/src/bolero/device.rs
+++ b/src/bolero/device.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use crate::bolero::support::K8sObjectNameString;
+use crate::config::{Device, LogLevel, PacketDriver};
+use bolero::{Driver, TypeGenerator};
+
+impl TypeGenerator for Device {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(Device {
+            driver: i32::from(d.produce::<PacketDriver>()?),
+            eal: None,     // TODO Add support for EAL when dataplane supports it
+            ports: vec![], // TODO Add support for ports when dataplane supports it
+            hostname: d.produce::<K8sObjectNameString>()?.0,
+            loglevel: i32::from(d.produce::<LogLevel>()?),
+        })
+    }
+}

--- a/src/bolero/expose.rs
+++ b/src/bolero/expose.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use bolero::{Driver, TypeGenerator, ValueGenerator};
+use std::ops::Bound;
+
+use crate::bolero::support::{UniqueV4CidrGenerator, UniqueV6CidrGenerator};
+use crate::config::{Expose, PeeringAs, PeeringIPs, peering_as, peering_i_ps};
+
+struct UniquePeeringAs<T: ValueGenerator<Output = Vec<String>>> {
+    cidr_producer: T,
+}
+
+impl<T: ValueGenerator<Output = Vec<String>>> UniquePeeringAs<T> {
+    pub fn new(cidr_producer: T) -> Self {
+        Self { cidr_producer }
+    }
+}
+
+impl<T> ValueGenerator for UniquePeeringAs<T>
+where
+    T: ValueGenerator<Output = Vec<String>>,
+{
+    type Output = Vec<PeeringAs>;
+
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<Self::Output> {
+        let cidrs = self.cidr_producer.generate(d)?;
+        let r#as = (0..cidrs.len())
+            .map(|i| {
+                let use_not = d.gen_bool(None)?;
+                let cidr = cidrs[i].clone();
+                let rule = if use_not {
+                    peering_as::Rule::Not(cidr)
+                } else {
+                    peering_as::Rule::Cidr(cidr)
+                };
+                Some(PeeringAs { rule: Some(rule) })
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Some(r#as)
+    }
+}
+
+struct UniquePeeringIPs<T: ValueGenerator<Output = Vec<String>>> {
+    cidr_producer: T,
+}
+
+impl<T: ValueGenerator<Output = Vec<String>>> UniquePeeringIPs<T> {
+    pub fn new(cidr_producer: T) -> Self {
+        Self { cidr_producer }
+    }
+}
+
+impl<T> ValueGenerator for UniquePeeringIPs<T>
+where
+    T: ValueGenerator<Output = Vec<String>>,
+{
+    type Output = Vec<PeeringIPs>;
+
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<Self::Output> {
+        let cidrs = self.cidr_producer.generate(d)?;
+        let ips = (0..cidrs.len())
+            .map(|i| {
+                let use_not = d.gen_bool(None)?;
+                let cidr = cidrs[i].clone();
+                let rule = if use_not {
+                    peering_i_ps::Rule::Not(cidr)
+                } else {
+                    peering_i_ps::Rule::Cidr(cidr)
+                };
+                Some(PeeringIPs { rule: Some(rule) })
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Some(ips)
+    }
+}
+
+// FIXME(manishv): We should make sure that the number of peering ips and ases are
+// consistent.
+// FIXME(manishv): We should also make sure that the cidrs use not
+impl TypeGenerator for Expose {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let v4 = d.gen_bool(None)?;
+        let len = d.gen_u16(Bound::Included(&1), Bound::Included(&10))?;
+        let v4_mask: u8 = d.gen_u8(Bound::Included(&8), Bound::Included(&32))?;
+        let v6_mask: u8 = d.gen_u8(Bound::Included(&16), Bound::Included(&128))?;
+
+        let peering_ips = if v4 {
+            let v4_cidr_producer_ips =
+                UniquePeeringIPs::new(UniqueV4CidrGenerator::new(len, v4_mask));
+            v4_cidr_producer_ips.generate(d)?
+        } else {
+            let v6_cidr_producer_ips =
+                UniquePeeringIPs::new(UniqueV6CidrGenerator::new(len, v6_mask));
+            v6_cidr_producer_ips.generate(d)?
+        };
+
+        let has_as = d.gen_bool(None)?;
+        let r#as = if has_as {
+            if v4 {
+                let v4_cidr_producer_as =
+                    UniquePeeringAs::new(UniqueV4CidrGenerator::new(len, v4_mask));
+                v4_cidr_producer_as.generate(d)?
+            } else {
+                let v6_cidr_producer_as =
+                    UniquePeeringAs::new(UniqueV6CidrGenerator::new(len, v6_mask));
+                v6_cidr_producer_as.generate(d)?
+            }
+        } else {
+            vec![]
+        };
+
+        Some(Expose {
+            ips: peering_ips,
+            r#as,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::bolero::test_support::parse_cidr;
+    use crate::bolero::test_support::{get_peering_as_ip, get_peering_ip};
+    use std::net::IpAddr;
+
+    enum IpAddrType {
+        V4,
+        V6,
+        Unknown,
+    }
+
+    fn ip_type_same(ips: &[IpAddr]) -> bool {
+        let mut ip_type = IpAddrType::Unknown;
+        for ip in ips {
+            match (ip, &ip_type) {
+                (IpAddr::V4(_), &IpAddrType::Unknown) => ip_type = IpAddrType::V4,
+                (IpAddr::V6(_), &IpAddrType::Unknown) => ip_type = IpAddrType::V6,
+                (IpAddr::V4(_), &IpAddrType::V6) | (IpAddr::V6(_), &IpAddrType::V4) => {
+                    return false;
+                }
+                _ => {}
+            }
+        }
+        true
+    }
+
+    #[test]
+    fn test_expose() {
+        let mut more_than_one = false;
+        bolero::check!()
+            .with_type::<Expose>()
+            .for_each(|expose: &Expose| {
+                assert!(!expose.ips.is_empty());
+                if expose.ips.len() > 1 {
+                    more_than_one = true;
+                }
+                assert!(ip_type_same(
+                    expose
+                        .ips
+                        .iter()
+                        .map(|ip| parse_cidr(get_peering_ip(ip).unwrap()).unwrap().0)
+                        .collect::<Vec<_>>()
+                        .as_slice()
+                ));
+                assert!(ip_type_same(
+                    expose
+                        .r#as
+                        .iter()
+                        .map(|r#as| parse_cidr(get_peering_as_ip(r#as).unwrap()).unwrap().0)
+                        .collect::<Vec<_>>()
+                        .as_slice()
+                ));
+            });
+        assert!(more_than_one);
+    }
+}

--- a/src/bolero/gateway_config.rs
+++ b/src/bolero/gateway_config.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use crate::config::{Device, GatewayConfig, Overlay, Underlay, Vpc, VpcPeering, Vrf};
+use bolero::{Driver, TypeGenerator};
+use std::ops::Bound;
+
+// FIXME: Only generate peerings between vpcs named in vpc list
+impl TypeGenerator for Overlay {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let nvpcs = d.gen_usize(Bound::Included(&0), Bound::Included(&10))?;
+        let npeerings = d.gen_usize(Bound::Included(&0), Bound::Included(&10))?;
+        let mut next_vni = 1;
+        let mut peering_num = 0;
+        Some(Overlay {
+            vpcs: (0..nvpcs)
+                .map(|_| {
+                    let mut vpc = d.produce::<Vpc>()?;
+                    vpc.vni = next_vni;
+                    vpc.id = format!("{next_vni:05}");
+                    vpc.name = format!("{next_vni:05}");
+                    next_vni += 1;
+                    Some(vpc)
+                })
+                .collect::<Option<Vec<_>>>()?,
+            peerings: (0..npeerings)
+                .map(|_| {
+                    let mut peering = d.produce::<VpcPeering>()?;
+                    peering.name = format!("peering{peering_num}");
+                    peering_num += 1;
+                    Some(peering)
+                })
+                .collect::<Option<Vec<_>>>()?,
+        })
+    }
+}
+
+impl TypeGenerator for Underlay {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        // Dataplane currently only supports a single vrf
+        const MAX_UNDERLAY_VRFS: usize = 1;
+        let nvrfs = d.gen_usize(Bound::Included(&1), Bound::Included(&MAX_UNDERLAY_VRFS))?;
+        Some(Underlay {
+            vrfs: (0..nvrfs)
+                .map(|_| d.produce::<Vrf>())
+                .collect::<Option<Vec<_>>>()?,
+        })
+    }
+}
+
+impl TypeGenerator for GatewayConfig {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(GatewayConfig {
+            generation: d.gen_i64(Bound::Included(&0), Bound::Included(&1000))?,
+            device: Some(d.produce::<Device>()?),
+            overlay: Some(d.produce::<Overlay>()?),
+            underlay: Some(d.produce::<Underlay>()?),
+        })
+    }
+}
+#[cfg(test)]
+mod test {
+    use crate::config::{Overlay, Underlay};
+
+    #[test]
+    fn test_overlay() {
+        bolero::check!()
+            .with_type::<Overlay>()
+            .for_each(|_overlay| {
+                // Other tests cover the interesting stuff, this just makes sure the generator doesn't panic
+            });
+    }
+
+    #[test]
+    fn test_underlay() {
+        bolero::check!()
+            .with_type::<Underlay>()
+            .for_each(|_underlay| {
+                // Other tests cover the interesting stuff, this just makes sure the generator doesn't panic
+            });
+    }
+}

--- a/src/bolero/impl_peering_as.rs
+++ b/src/bolero/impl_peering_as.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use crate::bolero::support::CidrString;
+use crate::config::{PeeringAs, peering_as as config_peering_as};
+use bolero::{Driver, TypeGenerator};
+
+impl TypeGenerator for PeeringAs {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(PeeringAs {
+            rule: Some(d.produce::<config_peering_as::Rule>()?),
+        })
+    }
+}
+
+impl TypeGenerator for config_peering_as::Rule {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let not = d.gen_bool(None)?;
+        if not {
+            Some(config_peering_as::Rule::Not(d.produce::<CidrString>()?.0))
+        } else {
+            Some(config_peering_as::Rule::Cidr(d.produce::<CidrString>()?.0))
+        }
+    }
+}
+
+pub mod peering_as {
+    use crate::bolero::support::{V4CidrString, V6CidrString};
+    use crate::config::peering_as::Rule;
+    use bolero::{Driver, TypeGenerator};
+
+    pub struct V4Rule(pub Rule);
+    pub struct V6Rule(pub Rule);
+
+    impl TypeGenerator for V4Rule {
+        fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+            let not = d.gen_bool(None)?;
+            let cidr = d.produce::<V4CidrString>()?.0;
+            if not {
+                Some(V4Rule(Rule::Not(cidr)))
+            } else {
+                Some(V4Rule(Rule::Cidr(cidr)))
+            }
+        }
+    }
+
+    impl TypeGenerator for V6Rule {
+        fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+            let not = d.gen_bool(None)?;
+            let cidr = d.produce::<V6CidrString>()?.0;
+            if not {
+                Some(V6Rule(Rule::Not(cidr)))
+            } else {
+                Some(V6Rule(Rule::Cidr(cidr)))
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct V4PeeringAs(pub PeeringAs);
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct V6PeeringAs(pub PeeringAs);
+
+impl TypeGenerator for V4PeeringAs {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(V4PeeringAs(PeeringAs {
+            rule: Some(d.produce::<peering_as::V4Rule>()?.0),
+        }))
+    }
+}
+
+impl TypeGenerator for V6PeeringAs {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(V6PeeringAs(PeeringAs {
+            rule: Some(d.produce::<peering_as::V6Rule>()?.0),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::bolero::test_support::parse_cidr;
+    use crate::bolero::{V4PeeringAs, V6PeeringAs};
+    use crate::config::{PeeringAs, peering_as as config_peering_as};
+    use std::net::IpAddr;
+    #[test]
+    fn test_peering_as() {
+        bolero::check!()
+            .with_type::<PeeringAs>()
+            .for_each(|peering_as: &PeeringAs| {
+                assert!(peering_as.rule.is_some());
+                let rule = peering_as.rule.as_ref().unwrap();
+                match rule {
+                    config_peering_as::Rule::Cidr(cidr) | config_peering_as::Rule::Not(cidr) => {
+                        assert!(parse_cidr(cidr).is_ok());
+                    }
+                }
+            });
+    }
+
+    fn test_peering_as_rule<T>(rule: &config_peering_as::Rule, test: T)
+    where
+        T: FnOnce(IpAddr, u8),
+    {
+        let (ip, mask) = match rule {
+            config_peering_as::Rule::Cidr(cidr) | config_peering_as::Rule::Not(cidr) => {
+                parse_cidr(cidr).unwrap()
+            }
+        };
+        test(ip, mask);
+    }
+
+    #[test]
+    fn test_v4_peering_as() {
+        bolero::check!()
+            .with_type::<V4PeeringAs>()
+            .for_each(|v4_peering_as: &V4PeeringAs| {
+                assert!(v4_peering_as.0.rule.is_some());
+                let rule = v4_peering_as.0.rule.as_ref().unwrap();
+                test_peering_as_rule(rule, |ip, mask| {
+                    assert!(ip.is_ipv4());
+                    assert!(mask <= 32);
+                });
+            });
+    }
+
+    #[test]
+    fn test_v6_peering_as() {
+        bolero::check!()
+            .with_type::<V6PeeringAs>()
+            .for_each(|v6_peering_as: &V6PeeringAs| {
+                assert!(v6_peering_as.0.rule.is_some());
+                let rule = v6_peering_as.0.rule.as_ref().unwrap();
+                test_peering_as_rule(rule, |ip, mask| {
+                    assert!(ip.is_ipv6());
+                    assert!(mask <= 128);
+                });
+            });
+    }
+}

--- a/src/bolero/impl_peering_i_ps.rs
+++ b/src/bolero/impl_peering_i_ps.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use crate::bolero::support::CidrString;
+use crate::config::{PeeringIPs, peering_i_ps as config_peering_i_ps};
+use bolero::{Driver, TypeGenerator};
+
+impl TypeGenerator for config_peering_i_ps::Rule {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let not = d.gen_bool(None)?;
+        if not {
+            Some(config_peering_i_ps::Rule::Not(d.produce::<CidrString>()?.0))
+        } else {
+            Some(config_peering_i_ps::Rule::Cidr(
+                d.produce::<CidrString>()?.0,
+            ))
+        }
+    }
+}
+
+pub mod peering_i_ps {
+    use crate::bolero::support::{V4CidrString, V6CidrString};
+    use crate::config::peering_i_ps::Rule;
+    use bolero::{Driver, TypeGenerator};
+    pub struct V4Rule(pub Rule);
+    pub struct V6Rule(pub Rule);
+
+    impl TypeGenerator for V4Rule {
+        fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+            let not = d.gen_bool(None)?;
+            let cidr = d.produce::<V4CidrString>()?.0;
+            if not {
+                Some(V4Rule(Rule::Not(cidr)))
+            } else {
+                Some(V4Rule(Rule::Cidr(cidr)))
+            }
+        }
+    }
+
+    impl TypeGenerator for V6Rule {
+        fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+            let not = d.gen_bool(None)?;
+            let cidr = d.produce::<V6CidrString>()?.0;
+            if not {
+                Some(V6Rule(Rule::Not(cidr)))
+            } else {
+                Some(V6Rule(Rule::Cidr(cidr)))
+            }
+        }
+    }
+}
+
+impl TypeGenerator for PeeringIPs {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(PeeringIPs {
+            // rule should never be None?
+            rule: Some(d.produce::<config_peering_i_ps::Rule>()?),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct V4PeeringIPs(pub PeeringIPs);
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct V6PeeringIPs(pub PeeringIPs);
+
+impl TypeGenerator for V4PeeringIPs {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(V4PeeringIPs(PeeringIPs {
+            rule: Some(d.produce::<peering_i_ps::V4Rule>()?.0),
+        }))
+    }
+}
+
+impl TypeGenerator for V6PeeringIPs {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(V6PeeringIPs(PeeringIPs {
+            rule: Some(d.produce::<peering_i_ps::V6Rule>()?.0),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::IpAddr;
+
+    use crate::bolero::test_support::parse_cidr;
+    use crate::bolero::{V4PeeringIPs, V6PeeringIPs};
+    use crate::config::{PeeringIPs, peering_i_ps as config_peering_i_ps};
+
+    #[test]
+    fn test_peering_ips() {
+        bolero::check!()
+            .with_type::<PeeringIPs>()
+            .for_each(|peering_ips: &PeeringIPs| {
+                assert!(peering_ips.rule.is_some());
+                let rule = peering_ips.rule.as_ref().unwrap();
+                match rule {
+                    config_peering_i_ps::Rule::Cidr(cidr)
+                    | config_peering_i_ps::Rule::Not(cidr) => {
+                        assert!(parse_cidr(cidr).is_ok());
+                    }
+                }
+            });
+    }
+
+    fn test_peering_ip_rule<T>(rule: &config_peering_i_ps::Rule, test: T)
+    where
+        T: FnOnce(IpAddr, u8),
+    {
+        let (ip, mask) = match rule {
+            config_peering_i_ps::Rule::Cidr(cidr) | config_peering_i_ps::Rule::Not(cidr) => {
+                parse_cidr(cidr).unwrap()
+            }
+        };
+        test(ip, mask);
+    }
+
+    #[test]
+    fn test_v4_peering_ips() {
+        bolero::check!()
+            .with_type::<V4PeeringIPs>()
+            .for_each(|v4_peering_ips: &V4PeeringIPs| {
+                assert!(v4_peering_ips.0.rule.is_some());
+                let rule = v4_peering_ips.0.rule.as_ref().unwrap();
+                test_peering_ip_rule(rule, |ip, mask| {
+                    assert!(ip.is_ipv4());
+                    assert!(mask <= 32);
+                });
+            });
+    }
+
+    #[test]
+    fn test_v6_peering_ips() {
+        bolero::check!()
+            .with_type::<V6PeeringIPs>()
+            .for_each(|v6_peering_ips: &V6PeeringIPs| {
+                assert!(v6_peering_ips.0.rule.is_some());
+                let rule = v6_peering_ips.0.rule.as_ref().unwrap();
+                test_peering_ip_rule(rule, |ip, mask| {
+                    assert!(ip.is_ipv6());
+                    assert!(mask <= 128);
+                });
+            });
+    }
+}

--- a/src/bolero/interface.rs
+++ b/src/bolero/interface.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use crate::bolero::support::{
+    Ipv4AddrString, LinuxIfName, MacAddrString, UniqueV4CidrGenerator, UniqueV6CidrGenerator,
+};
+use crate::config::{IfRole, IfType, Interface, OspfConfig, OspfInterface, OspfNetworkType};
+use bolero::{Driver, TypeGenerator, ValueGenerator};
+use std::ops::Bound;
+
+impl TypeGenerator for OspfInterface {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let area = d.produce::<Ipv4AddrString>()?.0;
+        Some(OspfInterface {
+            passive: d.produce()?,
+            area, // Should this be Ipv4 or Ipv6 or a random integer?
+            cost: d.produce()?,
+            network_type: Some(d.produce::<OspfNetworkType>()?.into()),
+        })
+    }
+}
+
+impl TypeGenerator for OspfConfig {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let router_id = d.produce::<Ipv4AddrString>()?.0;
+        Some(OspfConfig {
+            router_id,
+            vrf: if d.gen_bool(None)? {
+                Some(d.produce::<LinuxIfName>()?.0)
+            } else {
+                None
+            },
+        })
+    }
+}
+
+impl TypeGenerator for Interface {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let r#type: IfType = d.produce()?;
+        let ipaddrs = if d.gen_bool(None)? || r#type == IfType::Vtep {
+            match r#type {
+                IfType::Ethernet | IfType::Loopback | IfType::Vlan => {
+                    let count_v4 = d.gen_u16(Bound::Included(&0), Bound::Included(&10))?;
+                    let count_v6 = d.gen_u16(Bound::Included(&0), Bound::Included(&10))?;
+                    let mask_v4 = d.gen_u8(Bound::Included(&1), Bound::Included(&32))?;
+                    let mask_v6 = d.gen_u8(Bound::Included(&1), Bound::Included(&128))?;
+                    let cidrs_v4 = UniqueV4CidrGenerator::new(count_v4, mask_v4).generate(d)?;
+                    let cidrs_v6 = UniqueV6CidrGenerator::new(count_v6, mask_v6).generate(d)?;
+                    cidrs_v4.into_iter().chain(cidrs_v6).collect()
+                }
+                IfType::Vtep => vec![format!("{}/32", d.produce::<Ipv4AddrString>()?.0)],
+            }
+        } else {
+            vec![]
+        };
+
+        let vlan = match r#type {
+            IfType::Ethernet | IfType::Loopback | IfType::Vtep => None,
+            IfType::Vlan => Some(u32::from(
+                // 12 bits for VLAN ID, max of 4096 - 2
+                d.gen_u16(Bound::Included(&1), Bound::Included(&(4096 - 2)))?,
+            )),
+        };
+
+        let macaddr = match r#type {
+            IfType::Ethernet | IfType::Vlan => Some(d.produce::<MacAddrString>()?.0),
+            _ => None,
+        };
+
+        let ospf = match r#type {
+            IfType::Ethernet | IfType::Vlan => {
+                if d.gen_bool(None)? {
+                    Some(d.produce::<OspfInterface>()?)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        Some(Interface {
+            name: d.produce::<LinuxIfName>()?.0,
+            ipaddrs,
+            r#type: r#type.into(),
+            role: IfRole::Fabric.into(), // Dataplane only supports Fabric for now - d.produce::<IfRole>()?.into(),
+            vlan,
+            macaddr,
+            ospf,
+            system_name: None, // We do not support system names right now
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::config::{IfType, Interface, OspfConfig, OspfInterface};
+
+    #[test]
+    fn test_ospf_interface() {
+        bolero::check!()
+            .with_type::<OspfInterface>()
+            .for_each(|intf: &OspfInterface| {
+                assert!(intf.area.parse::<std::net::Ipv4Addr>().is_ok());
+            });
+    }
+
+    #[test]
+    fn test_ospf_config() {
+        bolero::check!()
+            .with_type::<OspfConfig>()
+            .for_each(|config: &OspfConfig| {
+                assert!(config.router_id.parse::<std::net::Ipv4Addr>().is_ok());
+            });
+    }
+
+    #[test]
+    fn test_interface() {
+        bolero::check!()
+            .with_type::<Interface>()
+            .for_each(|intf: &Interface| {
+                assert!(
+                    intf.name.len() <= 16,
+                    "Interface name too long: {} len: {}",
+                    intf.name,
+                    intf.name.len()
+                );
+                assert!(intf.ipaddrs.iter().all(|cidr| {
+                    let (ip, _mask) = cidr.split_once('/').unwrap();
+                    ip.parse::<std::net::Ipv4Addr>().is_ok()
+                        || ip.parse::<std::net::Ipv6Addr>().is_ok()
+                }));
+                if intf.r#type == i32::from(IfType::Vtep) {
+                    assert!(intf.ipaddrs.len() == 1);
+                    let (ip, mask) = intf.ipaddrs[0].split_once('/').unwrap();
+                    // Dataplane only supports v4 VTEP IPs right now
+                    assert!(ip.parse::<std::net::Ipv4Addr>().is_ok());
+                    assert_eq!(mask, "32");
+                }
+                assert!(intf.macaddr.is_some() || intf.r#type != i32::from(IfType::Ethernet));
+                assert!(intf.vlan.is_some() || intf.r#type != i32::from(IfType::Vlan));
+                assert!(intf.ospf.is_none() || intf.r#type != i32::from(IfType::Loopback));
+                assert!(intf.ospf.is_none() || intf.r#type != i32::from(IfType::Vtep));
+                assert!(intf.system_name.is_none());
+            });
+    }
+}

--- a/src/bolero/mod.rs
+++ b/src/bolero/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod test {}

--- a/src/bolero/mod.rs
+++ b/src/bolero/mod.rs
@@ -1,5 +1,32 @@
-// Copyright 2025 Hedgehog
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
 
+mod bgp;
+mod device;
+mod expose;
+mod gateway_config;
+mod impl_peering_as;
+mod impl_peering_i_ps;
+mod interface;
+pub mod support;
 #[cfg(test)]
-mod test {}
+pub mod test_support;
+mod vpc;
+mod vrf;
+
+#[allow(unused)] // Currently only implements traits, remove if we export anything
+pub use bgp::*;
+#[allow(unused)] // Currently only implements traits, remove if we export anything
+pub use device::*;
+#[allow(unused)] // Currently only implements traits, remove if we export anything
+pub use expose::*;
+#[allow(unused)] // Currently only implements traits, remove if we export anything
+pub use gateway_config::*;
+pub use impl_peering_as::*;
+pub use impl_peering_i_ps::*;
+#[allow(unused)] // Currently only implements traits, remove if we export anything
+pub use interface::*;
+#[allow(unused)] // Currently only implements traits, remove if we export anything
+pub use vpc::*;
+#[allow(unused)] // Currently only implements traits, remove if we export anything
+pub use vrf::*;

--- a/src/bolero/support.rs
+++ b/src/bolero/support.rs
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use bolero::{Driver, TypeGenerator, ValueGenerator};
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::ops::Bound;
+
+pub fn gen_from_chars<D: Driver>(
+    d: &mut D,
+    chars: &str,
+    min: std::ops::Bound<&usize>,
+    max: std::ops::Bound<&usize>,
+) -> Option<String> {
+    let len = d.gen_usize(min, max)?;
+    (0..len)
+        .map(|_| {
+            chars
+                .chars()
+                .nth(d.gen_usize(Bound::Included(&0), Bound::Excluded(&chars.len()))?)
+        })
+        .collect()
+}
+
+pub struct Ipv4AddrString(pub String);
+
+impl TypeGenerator for Ipv4AddrString {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(Ipv4AddrString(
+            Ipv4Addr::from(d.gen_u32(
+                Bound::Included(&0x1000_0000_u32),
+                Bound::Excluded(&0xffff_ffff_u32),
+            )?)
+            .to_string(),
+        ))
+    }
+}
+
+pub struct Ipv6AddrString(pub String);
+
+impl TypeGenerator for Ipv6AddrString {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(Ipv6AddrString(
+            Ipv6Addr::from(d.gen_u128(
+                Bound::Included(&0x0000_0000_0000_0000_0000_0000_0000_0001_u128),
+                Bound::Excluded(&0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128),
+            )?)
+            .to_string(),
+        ))
+    }
+}
+
+pub struct IpAddrString(pub String);
+
+impl TypeGenerator for IpAddrString {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let is_ipv4 = d.gen_bool(None)?;
+        if is_ipv4 {
+            Some(IpAddrString(d.produce::<Ipv4AddrString>()?.0))
+        } else {
+            Some(IpAddrString(d.produce::<Ipv6AddrString>()?.0))
+        }
+    }
+}
+
+mod unstable_unbounded_shift {
+    // Unbounded shift is unstable in Rust 1.86.0
+    // Remove when we upgrade to Rust 1.87.0
+    // We should get an unused trait error with 1.87.0
+    pub(crate) trait UnboundedShift {
+        fn unbounded_shl(self, rhs: u32) -> Self;
+        fn unbounded_shr(self, rhs: u32) -> Self;
+    }
+
+    impl UnboundedShift for u32 {
+        fn unbounded_shl(self, amt: u32) -> Self {
+            let (ret, overflow) = self.overflowing_shl(amt);
+            if overflow { 0 } else { ret }
+        }
+
+        fn unbounded_shr(self, amt: u32) -> Self {
+            let (ret, overflow) = self.overflowing_shr(amt);
+            if overflow { 0 } else { ret }
+        }
+    }
+
+    impl UnboundedShift for u128 {
+        fn unbounded_shl(self, amt: u32) -> Self {
+            let (ret, overflow) = self.overflowing_shl(amt);
+            if overflow { 0 } else { ret }
+        }
+
+        fn unbounded_shr(self, amt: u32) -> Self {
+            let (ret, overflow) = self.overflowing_shr(amt);
+            if overflow { 0 } else { ret }
+        }
+    }
+}
+use unstable_unbounded_shift::UnboundedShift;
+
+pub struct V4CidrString(pub String);
+pub struct V6CidrString(pub String);
+pub struct CidrString(pub String);
+
+fn v4cdir_from_bytes(addr_bytes: u32, mask: u8) -> String {
+    // Remove this allow once we upgrade to Rust 1.87.0
+    #[allow(unstable_name_collisions)]
+    let and_mask = u32::MAX.unbounded_shl(32 - u32::from(mask));
+    let addr = Ipv4Addr::from(addr_bytes & and_mask);
+    format!("{addr}/{mask}")
+}
+
+fn v6cdir_from_bytes(addr_bytes: u128, mask: u8) -> String {
+    // Remove this allow once we upgrade to Rust 1.87.0
+    #[allow(unstable_name_collisions)]
+    let and_mask = u128::MAX.unbounded_shl(128 - u32::from(mask));
+    let addr = Ipv6Addr::from(addr_bytes & and_mask);
+    format!("{addr}/{mask}")
+}
+
+impl TypeGenerator for V4CidrString {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let mask = d.gen_u8(Bound::Included(&0), Bound::Included(&32))?;
+        let addr_bytes = d.produce::<u32>()?;
+        Some(V4CidrString(v4cdir_from_bytes(addr_bytes, mask)))
+    }
+}
+
+impl TypeGenerator for V6CidrString {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let mask: u8 = d.gen_u8(Bound::Included(&0), Bound::Included(&128))?;
+        let addr_bytes = d.produce::<u128>()?;
+        Some(V6CidrString(v6cdir_from_bytes(addr_bytes, mask)))
+    }
+}
+
+#[derive(Debug)]
+pub struct UniqueV4CidrGenerator {
+    count: u16,
+    mask: u8,
+}
+
+impl UniqueV4CidrGenerator {
+    #[must_use]
+    pub fn new(count: u16, mask: u8) -> Self {
+        Self { count, mask }
+    }
+}
+
+impl ValueGenerator for UniqueV4CidrGenerator {
+    // Remove this allow once we upgrade to Rust 1.87.0
+    #![allow(unstable_name_collisions)]
+    type Output = Vec<String>;
+
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<Self::Output> {
+        if self.mask == 0 && self.count > 0 {
+            d.produce::<u32>(); // generate a value to satisfiy the bolero driver
+            return Some(vec!["0.0.0.0/0".to_string()]);
+        }
+
+        let available_addrs = 1_u32.unbounded_shl(u32::from(self.mask));
+        let max_to_generate = if available_addrs > 0 {
+            // Unwrap should never fail here because count is u16 and we take the min
+            // The - 1 is to discount the 0 address which we won't generate
+            #[allow(clippy::unwrap_used)]
+            u16::try_from((available_addrs - 1).min(u32::from(self.count))).unwrap()
+        } else {
+            self.count
+        };
+
+        let addr_bytes_seed = d.gen_u32(
+            Bound::Included(&0x1000_0000_u32),
+            Bound::Included(&u32::MAX),
+        )?;
+        let mut cidrs = Vec::with_capacity(usize::from(self.count));
+        let mut addrs_left = max_to_generate;
+        let mut addr_bytes = addr_bytes_seed.unbounded_shr(u32::from(32 - self.mask));
+        let addr_bytes_mask = u32::MAX.unbounded_shr(u32::from(32 - self.mask));
+        while addrs_left > 0 {
+            if addr_bytes & addr_bytes_mask == 0 {
+                // Smallest valid v4 address with given mask
+                addr_bytes = 1;
+            }
+            let cidr = v4cdir_from_bytes(
+                addr_bytes.unbounded_shl(u32::from(32 - self.mask)),
+                self.mask,
+            );
+            cidrs.push(cidr);
+            addrs_left -= 1;
+            addr_bytes = addr_bytes.wrapping_add(1);
+        }
+        Some(cidrs)
+    }
+}
+
+#[derive(Debug)]
+pub struct UniqueV6CidrGenerator {
+    pub count: u16,
+    pub mask: u8,
+}
+
+impl UniqueV6CidrGenerator {
+    #[must_use]
+    pub fn new(count: u16, mask: u8) -> Self {
+        Self { count, mask }
+    }
+}
+
+impl ValueGenerator for UniqueV6CidrGenerator {
+    // Remove this allow once we upgrade to Rust 1.87.0
+    #![allow(unstable_name_collisions)]
+    type Output = Vec<String>;
+
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<Self::Output> {
+        if self.mask == 0 && self.count > 0 {
+            d.produce::<u32>(); // generate a value to satisfiy the bolero driver
+            return Some(vec!["::/0".to_string()]);
+        }
+
+        let available_addrs = 1_u128.unbounded_shl(u32::from(self.mask));
+
+        let max_to_generate = if available_addrs > 0 {
+            // Unwrap should never fail here because count is u16 and we take the min
+            // The - 1 is to discount the 0 address which we won't generate
+            #[allow(clippy::unwrap_used)]
+            u16::try_from((available_addrs - 1).min(u128::from(self.count))).unwrap()
+        } else {
+            self.count
+        };
+
+        let addr_bytes_seed = d.gen_u128(Bound::Included(&1_u128), Bound::Included(&u128::MAX))?;
+        let mut cidrs = Vec::with_capacity(usize::from(self.count));
+        let mut addrs_left = max_to_generate;
+        let mut addr_bytes = addr_bytes_seed.unbounded_shr(u32::from(128 - self.mask));
+        let addr_bytes_mask = u128::MAX.unbounded_shr(u32::from(128 - self.mask));
+        while addrs_left > 0 {
+            if addr_bytes & addr_bytes_mask == 0 {
+                // Smallest valid v6 address with mask
+                addr_bytes = 1;
+            }
+            let cidr = v6cdir_from_bytes(
+                addr_bytes.unbounded_shl(u32::from(128 - self.mask)),
+                self.mask,
+            );
+            cidrs.push(cidr);
+            addrs_left -= 1;
+            addr_bytes = addr_bytes.wrapping_add(1);
+        }
+        Some(cidrs)
+    }
+}
+
+impl TypeGenerator for CidrString {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let is_ipv4 = d.gen_bool(None)?;
+        if is_ipv4 {
+            Some(CidrString(d.produce::<V4CidrString>()?.0))
+        } else {
+            Some(CidrString(d.produce::<V6CidrString>()?.0))
+        }
+    }
+}
+
+pub const ALPHA_NUMERIC_CHARS: &str =
+    "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+pub struct MacAddrString(pub String);
+// Only generate lower case hex characters for mac addresses
+// because we cannot customize PartialEq for generated types
+// that use this, and we want to be able to compare generated
+// mac addresses with each other without concern for case.
+impl TypeGenerator for MacAddrString {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        // Generate a random 48-bit MAC address
+        let mac = d.gen_u64(Bound::Included(&1), Bound::Excluded(&0xffff_ffff_ffff_u64))?;
+        let bytes = [
+            (mac & 0xff) as u8,
+            ((mac >> 8) & 0xff) as u8,
+            ((mac >> 16) & 0xff) as u8,
+            ((mac >> 24) & 0xff) as u8,
+            ((mac >> 32) & 0xff) as u8,
+            ((mac >> 40) & 0xff) as u8,
+        ];
+        let mac_str = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5]
+        );
+        Some(MacAddrString(mac_str))
+    }
+}
+
+pub struct LinuxIfName(pub String);
+const IF_NAME_CHARS: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
+const IF_NAME_MAX_LEN: usize = 16;
+
+impl TypeGenerator for LinuxIfName {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        gen_from_chars(
+            d,
+            IF_NAME_CHARS,
+            Bound::Included(&1),
+            Bound::Included(&IF_NAME_MAX_LEN),
+        )
+        .map(LinuxIfName)
+    }
+}
+
+pub struct LinuxIfNamesGenerator {
+    pub count: u16,
+}
+
+impl ValueGenerator for LinuxIfNamesGenerator {
+    type Output = Vec<String>;
+
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<Self::Output> {
+        let ifnames = (0..self.count)
+            .map(|i| {
+                Some(format!(
+                    "{}{i}",
+                    gen_from_chars(
+                        d,
+                        IF_NAME_CHARS,
+                        Bound::Included(&1),
+                        Bound::Included(&(IF_NAME_MAX_LEN - 8)),
+                    )?
+                ))
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Some(ifnames)
+    }
+}
+pub struct K8sObjectNameString(pub String);
+
+const K8S_END_CHAR: &str = "abcdefghijklmnopqrstuvwxyz0123456789";
+const K8S_OTHER_CHARS: &str = "abcdefghijklmnopqrstuvwxyz0123456789-";
+const K8S_OBJ_MAX_LEN: usize = 63;
+
+impl TypeGenerator for K8sObjectNameString {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let len = d.gen_usize(Bound::Included(&2), Bound::Included(&K8S_OBJ_MAX_LEN))?;
+        let first_char = gen_from_chars(d, K8S_END_CHAR, Bound::Included(&1), Bound::Included(&1))?;
+        let middle_chars = gen_from_chars(
+            d,
+            K8S_OTHER_CHARS,
+            Bound::Included(&0),
+            Bound::Excluded(&(len - 2)),
+        )?;
+        let end_char = gen_from_chars(d, K8S_END_CHAR, Bound::Included(&0), Bound::Excluded(&1))?;
+
+        Some(K8sObjectNameString(format!(
+            "{first_char}{middle_chars}{end_char}"
+        )))
+    }
+}
+
+pub fn choose<T: Clone, D: Driver>(d: &mut D, choices: &[T]) -> Option<T> {
+    let index = d.gen_usize(Bound::Included(&0), Bound::Excluded(&choices.len()))?;
+    Some(choices[index].clone())
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_unique_v4_cidr_generator() {
+        for mask in 0..=32 {
+            let generator = crate::bolero::support::UniqueV4CidrGenerator::new(10, mask);
+            bolero::check!()
+                .with_generator(generator)
+                .with_iterations(1000) // Takes too long with auto-iterations
+                .for_each(|cidrs| {
+                    let mut seen = std::collections::HashSet::new();
+                    for cidr in cidrs {
+                        assert!(seen.insert(cidr), "Duplicate CIDR found: {cidr}");
+                    }
+                    assert!(
+                        !cidrs.is_empty(),
+                        "No CIDRs generated for mask={mask}, count=10"
+                    );
+                    assert!(cidrs.iter().all(|cidr| {
+                        let (ip, mask) = cidr.split_once('/').unwrap();
+                        assert!(mask.parse::<u8>().unwrap() <= 32);
+                        ip.parse::<std::net::Ipv4Addr>().is_ok()
+                    }));
+                });
+        }
+    }
+
+    #[test]
+    fn test_unique_v6_cidr_generator() {
+        for mask in 0..=128 {
+            let generator = crate::bolero::support::UniqueV6CidrGenerator::new(10, mask);
+            bolero::check!()
+                .with_generator(generator)
+                .with_iterations(1000) // Takes too long with auto-iterations
+                .for_each(|cidrs| {
+                    let mut seen = std::collections::HashSet::new();
+                    assert!(
+                        !cidrs.is_empty(),
+                        "No CIDRs generated for mask={mask}, count=10"
+                    );
+                    for cidr in cidrs {
+                        assert!(seen.insert(cidr), "Duplicate CIDR found: {cidr}");
+                    }
+                    assert!(cidrs.iter().all(|cidr| {
+                        let (ip, mask) = cidr.split_once('/').unwrap();
+                        assert!(mask.parse::<u8>().unwrap() <= 128);
+                        ip.parse::<std::net::Ipv6Addr>().is_ok()
+                    }));
+                });
+        }
+    }
+}

--- a/src/bolero/test_support.rs
+++ b/src/bolero/test_support.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use crate::config::{PeeringAs, PeeringIPs, peering_as, peering_i_ps};
+use thiserror::Error;
+#[derive(Debug, Error)]
+pub enum CidrParseError {
+    #[error("Unable to parse IP address: {0}")]
+    AddrParseError(#[from] std::net::AddrParseError),
+
+    #[error("Invalid mask for IP: {0}, {1}")]
+    MaskParseError(String, String),
+    #[error("Invalid mask length for IP: {0}, {1}")]
+    MaskLenError(u8, String),
+}
+
+/// Parse a CIDR string into an IP address and mask length.
+///
+/// # Errors
+///
+/// Returns an error if the CIDR string is invalid.
+///
+pub fn parse_cidr(cidr: &str) -> Result<(std::net::IpAddr, u8), CidrParseError> {
+    let parts: Vec<&str> = cidr.split('/').collect();
+    let ip = parts[0]
+        .parse::<std::net::IpAddr>()
+        .map_err(CidrParseError::AddrParseError)?;
+    let mask = parts[1]
+        .parse::<u8>()
+        .map_err(|_| CidrParseError::MaskParseError(parts[1].to_string(), cidr.to_string()))?;
+    if ip.is_ipv4() && mask > 32 {
+        return Err(CidrParseError::MaskLenError(mask, cidr.to_string()));
+    }
+    if ip.is_ipv6() && mask > 128 {
+        return Err(CidrParseError::MaskLenError(mask, cidr.to_string()));
+    }
+
+    Ok((ip, mask))
+}
+
+#[must_use]
+pub fn get_peering_ip(item: &PeeringIPs) -> Option<&str> {
+    match &item.rule {
+        Some(peering_i_ps::Rule::Cidr(ip) | peering_i_ps::Rule::Not(ip)) => Some(ip),
+        None => None,
+    }
+}
+
+#[must_use]
+pub fn get_peering_as_ip(item: &PeeringAs) -> Option<&str> {
+    match &item.rule {
+        Some(peering_as::Rule::Cidr(ip) | peering_as::Rule::Not(ip)) => Some(ip),
+        None => None,
+    }
+}

--- a/src/bolero/vpc.rs
+++ b/src/bolero/vpc.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use crate::bolero::support::{ALPHA_NUMERIC_CHARS, LinuxIfName, gen_from_chars};
+use crate::config::{Expose, Interface, PeeringEntryFor, Vpc, VpcPeering};
+use bolero::{Driver, TypeGenerator};
+use std::ops::Bound;
+impl TypeGenerator for PeeringEntryFor {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(PeeringEntryFor {
+            vpc: d.produce::<LinuxIfName>()?.0,
+            expose: vec![d.produce::<Expose>()?],
+        })
+    }
+}
+
+impl TypeGenerator for VpcPeering {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        Some(VpcPeering {
+            name: d.produce::<LinuxIfName>()?.0,
+            r#for: (0..2)
+                .map(|_| d.produce::<PeeringEntryFor>())
+                .collect::<Option<Vec<_>>>()?,
+        })
+    }
+}
+
+impl TypeGenerator for Vpc {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let nintf = d.gen_usize(Bound::Included(&1), Bound::Included(&10))?;
+        let mut iface_num = 0;
+        Some(Vpc {
+            name: d.produce::<LinuxIfName>()?.0,
+            id: gen_from_chars(
+                d,
+                ALPHA_NUMERIC_CHARS,
+                Bound::Included(&5),
+                Bound::Included(&5),
+            )?,
+            vni: d.gen_u32(Bound::Included(&1), Bound::Excluded(&(1 << 20)))?,
+            interfaces: (0..nintf)
+                .map(|_| {
+                    let mut iface = d.produce::<Interface>()?;
+                    let mut name = d.produce::<LinuxIfName>()?.0;
+                    if !name.is_empty() {
+                        name.pop();
+                    }
+                    iface.name = format!("{name}{iface_num}");
+                    iface_num += 1;
+                    Some(iface)
+                })
+                .collect::<Option<Vec<_>>>()?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::config::{PeeringEntryFor, VpcPeering};
+
+    #[test]
+    fn test_peering_entry_for() {
+        bolero::check!()
+            .with_type::<PeeringEntryFor>()
+            .for_each(|peering_entry_for| {
+                assert!(!peering_entry_for.vpc.is_empty());
+                assert!(!peering_entry_for.expose.is_empty());
+            });
+    }
+
+    #[test]
+    fn test_vpc_peering() {
+        bolero::check!()
+            .with_type::<VpcPeering>()
+            .for_each(|vpc_peering| {
+                assert!(!vpc_peering.name.is_empty());
+                assert!(!vpc_peering.r#for.is_empty());
+            });
+    }
+}

--- a/src/bolero/vrf.rs
+++ b/src/bolero/vrf.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
+
+use crate::bolero::support::{LinuxIfName, LinuxIfNamesGenerator, choose};
+use crate::config::{Interface, OspfConfig, RouterConfig, Vrf};
+use bolero::{Driver, TypeGenerator, ValueGenerator};
+use std::ops::Bound;
+
+impl TypeGenerator for Vrf {
+    fn generate<D: Driver>(d: &mut D) -> Option<Self> {
+        let router = d.produce::<RouterConfig>()?;
+        let ospf = d.produce::<OspfConfig>()?;
+        let ninterfaces = d.gen_u16(Bound::Included(&1), Bound::Included(&10))?;
+        let gen_if_names = LinuxIfNamesGenerator { count: ninterfaces };
+        let if_names = gen_if_names.generate(d)?;
+        let interfaces = (0..ninterfaces)
+            .enumerate()
+            .map(|(i, _)| {
+                let mut intf = d.produce::<Interface>()?;
+                intf.name.clone_from(&if_names[i]);
+                Some(intf)
+            })
+            .collect::<Option<Vec<_>>>()?;
+
+        Some(Vrf {
+            name: d.produce::<LinuxIfName>()?.0,
+            interfaces,
+            router: choose(d, &[Some(router), None])?,
+            ospf: choose(d, &[Some(ospf), None])?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::config::Vrf;
+
+    #[test]
+    fn test_vrf() {
+        let mut some_interfaces = false;
+        let mut some_router = false;
+        bolero::check!().with_type::<Vrf>().for_each(|vrf| {
+            assert!(!vrf.name.is_empty());
+            some_router = some_router || vrf.router.is_some();
+            some_interfaces = some_interfaces || !vrf.interfaces.is_empty();
+        });
+        assert!(some_router);
+        assert!(some_interfaces);
+    }
+}

--- a/src/generated/config.rs
+++ b/src/generated/config.rs
@@ -164,6 +164,7 @@ pub struct Overlay {
     pub peerings: ::prost::alloc::vec::Vec<VpcPeering>,
 }
 /// BGP options for IPv4 UNICAST AFI
+#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct BgpAddressFamilyIPv4 {
@@ -173,6 +174,7 @@ pub struct BgpAddressFamilyIPv4 {
     pub redistribute_static: bool,
 }
 /// BGP options for IPv6 UNICAST AFI
+#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct BgpAddressFamilyIPv6 {
@@ -182,6 +184,7 @@ pub struct BgpAddressFamilyIPv6 {
     pub redistribute_static: bool,
 }
 /// BGP options for L2VPN EVPN AFI
+#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct BgpAddressFamilyL2vpnEvpn {
@@ -356,6 +359,7 @@ impl Error {
     }
 }
 /// OSPF Network Type
+#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -390,6 +394,7 @@ impl OspfNetworkType {
     }
 }
 /// Defines interface representation on the Gateway
+#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -424,6 +429,7 @@ impl IfType {
     }
 }
 /// For physical interface - fabric-facing or external-facing
+#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -452,6 +458,7 @@ impl IfRole {
     }
 }
 /// AFIs supported for BGP peering
+#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -483,6 +490,7 @@ impl BgpAf {
     }
 }
 /// Log-level for dataplane and DPDK
+#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -520,6 +528,7 @@ impl LogLevel {
     }
 }
 /// Backend driver for packet processing
+#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,3 +67,6 @@ pub fn get_proto_path() -> std::path::PathBuf {
 }
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(feature = "bolero")]
+pub mod bolero;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod config {
     include!("generated/config.rs");
 }
 
+// Note(manishv): This is incomplete and not needed really, remove?
+// See https://github.com/githedgehog/gateway-proto/issues/28
 pub use config::{
     BgpAddressFamilyIPv4,
     BgpAddressFamilyIPv6,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright 2025 Hedgehog
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Hedgehog
 
 pub mod config {
     include!("generated/config.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Hedgehog
 
+#![deny(clippy::all, clippy::pedantic)]
+
+#[allow(clippy::pedantic)]
 pub mod config {
     include!("generated/config.rs");
 }
@@ -56,6 +59,7 @@ pub use config::{
     config_service_server::{ConfigService, ConfigServiceServer},
 };
 
+#[must_use]
 pub fn get_proto_path() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("proto")
 }


### PR DESCRIPTION
This adds `TypeGenerators` and `ValueGenerators` to allow Rust users of this library to fuzz test their consumption of gRPC objects.  The code is here instead of dataplane because of Rust's orphan rule for traits.

Please review but do not merge until [dpdk-sys#119 ](https://github.com/githedgehog/dpdk-sys/pull/119) is merged, as this PR requires Rust 1.87