### PR TITLE
Improve interface address generation in bolero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway_config"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.87.0"


### PR DESCRIPTION
This PR makes the bolero `Interface` `TypeGenerator` generate valid interface addresses (mostly, see below).  Previously, we were generating cidr prefixes which are not valid addresses for interfaces.

Prefixes and interface addresses, while using similar notation are not the same.  Prefixes ahve 0 in the low order bits, interface addresses, generally cannot:
```sh
10.1.0.1/16 # valid interface address, not a prefix
10.1.0.0/16 # valid prefix, network address so not a valid interface address
```

Note that /31 and /127 are exceptions:
```sh
10.1.1.0/31 # valid interface address
10.1.1.1/31 # valid interface address
```

Also all addresses with a /32 or /128 are valid (except v4 addresses that start with a leading 0 octet)

Note that this fix does not try to exclude multicast addresses, which are also illegal interface addresses.  I decided it was not worth it right now.  What is here is strictly better than what was there before.
