### PR TITLE
Add mac addresses for Vteps in fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway_config"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.87.0"


### PR DESCRIPTION
* Generates a mac address for Vtep interfaces in the interface type generator
* Make sure the mac address is a valid unicast mac address 