### PR TITLE
ci(runners): switch to finally migrated to hetzner runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,3 @@
 self-hosted-runner:
   labels:
     - lab
-    - vlab
-    - lab-h
-    - vlab-h

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   test:
-    runs-on: lab-h
+    runs-on: lab
 
     steps:
       - name: Checkout repository
@@ -85,7 +85,7 @@ jobs:
           limit-access-to-actor: true
 
   publish:
-    runs-on: lab-h
+    runs-on: lab
     if: startsWith(github.event.ref, 'refs/tags/v') && github.event_name == 'push'
     needs:
       - test


### PR DESCRIPTION
Enables githedgehog/lab#245