### PR TITLE
Fix BGP model for static network advertisements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway_config"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.87.0"

--- a/build.rs
+++ b/build.rs
@@ -25,8 +25,6 @@ fn main() {
         let bld = add_type_generators(
             bld,
             &[
-                "BgpAddressFamilyIPv4",
-                "BgpAddressFamilyIPv6",
                 "BgpAddressFamilyL2vpnEvpn",
                 "BgpAF",
                 "IfType",

--- a/pkg/dataplane/dataplane.pb.go
+++ b/pkg/dataplane/dataplane.pb.go
@@ -1276,6 +1276,7 @@ type BgpAddressFamilyIPv4 struct {
 	state                 protoimpl.MessageState `protogen:"open.v1"`
 	RedistributeConnected bool                   `protobuf:"varint,1,opt,name=redistribute_connected,json=redistributeConnected,proto3" json:"redistribute_connected,omitempty"`
 	RedistributeStatic    bool                   `protobuf:"varint,2,opt,name=redistribute_static,json=redistributeStatic,proto3" json:"redistribute_static,omitempty"`
+	Networks              []string               `protobuf:"bytes,3,rep,name=networks,proto3" json:"networks,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -1324,11 +1325,19 @@ func (x *BgpAddressFamilyIPv4) GetRedistributeStatic() bool {
 	return false
 }
 
+func (x *BgpAddressFamilyIPv4) GetNetworks() []string {
+	if x != nil {
+		return x.Networks
+	}
+	return nil
+}
+
 // BGP options for IPv6 UNICAST AFI
 type BgpAddressFamilyIPv6 struct {
 	state                 protoimpl.MessageState `protogen:"open.v1"`
 	RedistributeConnected bool                   `protobuf:"varint,1,opt,name=redistribute_connected,json=redistributeConnected,proto3" json:"redistribute_connected,omitempty"`
 	RedistributeStatic    bool                   `protobuf:"varint,2,opt,name=redistribute_static,json=redistributeStatic,proto3" json:"redistribute_static,omitempty"`
+	Networks              []string               `protobuf:"bytes,3,rep,name=networks,proto3" json:"networks,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -1375,6 +1384,13 @@ func (x *BgpAddressFamilyIPv6) GetRedistributeStatic() bool {
 		return x.RedistributeStatic
 	}
 	return false
+}
+
+func (x *BgpAddressFamilyIPv6) GetNetworks() []string {
+	if x != nil {
+		return x.Networks
+	}
+	return nil
 }
 
 // BGP options for L2VPN EVPN AFI
@@ -1511,7 +1527,6 @@ type BgpNeighbor struct {
 	RemoteAsn     string                   `protobuf:"bytes,2,opt,name=remote_asn,json=remoteAsn,proto3" json:"remote_asn,omitempty"`
 	AfActivate    []BgpAF                  `protobuf:"varint,3,rep,packed,name=af_activate,json=afActivate,proto3,enum=config.BgpAF" json:"af_activate,omitempty"`
 	UpdateSource  *BgpNeighborUpdateSource `protobuf:"bytes,4,opt,name=update_source,json=updateSource,proto3" json:"update_source,omitempty"`
-	Networks      []string                 `protobuf:"bytes,5,rep,name=networks,proto3" json:"networks,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1570,13 +1585,6 @@ func (x *BgpNeighbor) GetAfActivate() []BgpAF {
 func (x *BgpNeighbor) GetUpdateSource() *BgpNeighborUpdateSource {
 	if x != nil {
 		return x.UpdateSource
-	}
-	return nil
-}
-
-func (x *BgpNeighbor) GetNetworks() []string {
-	if x != nil {
-		return x.Networks
 	}
 	return nil
 }
@@ -2166,27 +2174,28 @@ const file_proto_dataplane_proto_rawDesc = "" +
 	"interfaces\"Z\n" +
 	"\aOverlay\x12\x1f\n" +
 	"\x04vpcs\x18\x01 \x03(\v2\v.config.VPCR\x04vpcs\x12.\n" +
-	"\bpeerings\x18\x02 \x03(\v2\x12.config.VpcPeeringR\bpeerings\"~\n" +
+	"\bpeerings\x18\x02 \x03(\v2\x12.config.VpcPeeringR\bpeerings\"\x9a\x01\n" +
 	"\x14BgpAddressFamilyIPv4\x125\n" +
 	"\x16redistribute_connected\x18\x01 \x01(\bR\x15redistributeConnected\x12/\n" +
-	"\x13redistribute_static\x18\x02 \x01(\bR\x12redistributeStatic\"~\n" +
+	"\x13redistribute_static\x18\x02 \x01(\bR\x12redistributeStatic\x12\x1a\n" +
+	"\bnetworks\x18\x03 \x03(\tR\bnetworks\"\x9a\x01\n" +
 	"\x14BgpAddressFamilyIPv6\x125\n" +
 	"\x16redistribute_connected\x18\x01 \x01(\bR\x15redistributeConnected\x12/\n" +
-	"\x13redistribute_static\x18\x02 \x01(\bR\x12redistributeStatic\"G\n" +
+	"\x13redistribute_static\x18\x02 \x01(\bR\x12redistributeStatic\x12\x1a\n" +
+	"\bnetworks\x18\x03 \x03(\tR\bnetworks\"G\n" +
 	"\x19BgpAddressFamilyL2vpnEvpn\x12*\n" +
 	"\x11advertise_all_vni\x18\x01 \x01(\bR\x0fadvertiseAllVni\"_\n" +
 	"\x17BgpNeighborUpdateSource\x12\x1a\n" +
 	"\aaddress\x18\x01 \x01(\tH\x00R\aaddress\x12\x1e\n" +
 	"\tinterface\x18\x02 \x01(\tH\x00R\tinterfaceB\b\n" +
-	"\x06source\"\xd8\x01\n" +
+	"\x06source\"\xbc\x01\n" +
 	"\vBgpNeighbor\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x1d\n" +
 	"\n" +
 	"remote_asn\x18\x02 \x01(\tR\tremoteAsn\x12.\n" +
 	"\vaf_activate\x18\x03 \x03(\x0e2\r.config.BgpAFR\n" +
 	"afActivate\x12D\n" +
-	"\rupdate_source\x18\x04 \x01(\v2\x1f.config.BgpNeighborUpdateSourceR\fupdateSource\x12\x1a\n" +
-	"\bnetworks\x18\x05 \x03(\tR\bnetworks\"\x80\x01\n" +
+	"\rupdate_source\x18\x04 \x01(\v2\x1f.config.BgpNeighborUpdateSourceR\fupdateSource\"\x80\x01\n" +
 	"\bRouteMap\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12,\n" +
 	"\x12match_prefix_lists\x18\x02 \x03(\tR\x10matchPrefixLists\x12\x16\n" +

--- a/proto/dataplane.proto
+++ b/proto/dataplane.proto
@@ -156,12 +156,14 @@ message Overlay {
 message BgpAddressFamilyIPv4 {
   bool redistribute_connected = 1;
   bool redistribute_static = 2;
+  repeated string networks = 3;
 }
 
 /* BGP options for IPv6 UNICAST AFI */
 message BgpAddressFamilyIPv6 {
   bool redistribute_connected = 1;
   bool redistribute_static = 2;
+  repeated string networks = 3;
 }
 
 /* BGP options for L2VPN EVPN AFI */
@@ -190,7 +192,6 @@ message BgpNeighbor {
   string remote_asn = 2;
   repeated BgpAF af_activate = 3;
   BgpNeighborUpdateSource update_source = 4;
-  repeated string networks = 5;
 }
 
 /* IP Prefix filtering route map description */

--- a/src/generated/config.rs
+++ b/src/generated/config.rs
@@ -167,24 +167,26 @@ pub struct Overlay {
     pub peerings: ::prost::alloc::vec::Vec<VpcPeering>,
 }
 /// BGP options for IPv4 UNICAST AFI
-#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BgpAddressFamilyIPv4 {
     #[prost(bool, tag = "1")]
     pub redistribute_connected: bool,
     #[prost(bool, tag = "2")]
     pub redistribute_static: bool,
+    #[prost(string, repeated, tag = "3")]
+    pub networks: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// BGP options for IPv6 UNICAST AFI
-#[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
 #[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BgpAddressFamilyIPv6 {
     #[prost(bool, tag = "1")]
     pub redistribute_connected: bool,
     #[prost(bool, tag = "2")]
     pub redistribute_static: bool,
+    #[prost(string, repeated, tag = "3")]
+    pub networks: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// BGP options for L2VPN EVPN AFI
 #[cfg_attr(feature = "bolero", derive(::bolero::TypeGenerator))]
@@ -225,8 +227,6 @@ pub struct BgpNeighbor {
     pub af_activate: ::prost::alloc::vec::Vec<i32>,
     #[prost(message, optional, tag = "4")]
     pub update_source: ::core::option::Option<BgpNeighborUpdateSource>,
-    #[prost(string, repeated, tag = "5")]
-    pub networks: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// IP Prefix filtering route map description
 #[derive(::serde::Deserialize, ::serde::Serialize)]


### PR DESCRIPTION
BGP model associated advertisements with neighbor configuration, which is wrong.

The fix is to move the networks field into each address family.  This is, unfortunately, a breaking change.

Bump version number to 0.11.0 as a result