### PR TITLE
chore(rust): Add CI workflow to bump Rust dependencies

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,126 @@
+# Check for Cargo dependencies updates, and automatically open a Pull Request
+# if updates are found.
+
+name: "bump.yml"
+
+on:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: "boolean"
+        description: "Run with tmate enabled"
+        required: false
+        default: false
+  schedule:
+    # Check for updates at 3:18 am every day
+    # (Avoid midnight so we don't contribute to load spikes)
+    - cron: "18 3 * * *"
+
+concurrency:
+  group: "${{ github.workflow }}:${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: "write"
+  packages: "read"
+  id-token: "write"
+  pull-requests: "write"
+
+jobs:
+  cargo-upgrades:
+    runs-on: "lab"
+    steps:
+      - name: "install rust"
+        uses: "dtolnay/rust-toolchain@stable"
+      - name: "install ansi2txt"
+        run: |
+          # this keeps our GH actions logs from getting messed up with color codes
+          echo 'deb [trusted=yes] https://apt.gabe565.com /' | sudo tee /etc/apt/sources.list.d/gabe565.list
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends ansi2txt
+      - name: "install binstall"
+        run: |
+          cargo install cargo-binstall
+      - name: "install upgrade tools"
+        run: |
+          cargo binstall -y cargo-edit # required to make `cargo upgrade` edit the Cargo.toml file
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+      - name: "cargo upgrade"
+        id: upgrade
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '<41898282+github-actions[bot]@users.noreply.github.com>'
+          BASE="$(git rev-parse HEAD)"
+
+          # Run "cargo update"
+          just cargo update
+          if ! git diff --quiet; then
+              git add Cargo.lock
+              git commit -sm "bump(cargo)!: bump dependencies (cargo update)"
+          fi
+
+          # Check updates available with "cargo upgrade",
+          # then bump each package individually through separate commits
+          just cargo upgrade --incompatible=allow --dry-run > upgrade_output.txt
+          sed '/^====/d; /^name .* new req$/d; s/ .*//' upgrade_output.txt > list_packages.txt
+          nb_upgrades=$(wc -l < list_packages.txt)
+
+          echo "Found the following ${nb_upgrades} upgrade(s) available:"
+          cat list_packages.txt
+
+          while read -r package; do
+              echo "bump(cargo)!: bump $package (cargo upgrade)" | tee commit_msg.txt
+              echo '' | tee -a commit_msg.txt
+              just cargo upgrade --incompatible=allow --package "$package" | tee -a commit_msg.txt
+              git add Cargo.lock Cargo.toml
+              git commit -sF commit_msg.txt
+          done < list_packages.txt
+
+          # If we didn't create any commits, we don't need to create a PR message
+          if [[ "$(git rev-parse HEAD)" = "${BASE}" ]]; then
+              rm -f -- upgrade_output.txt list_packages.txt commit_msg.txt
+              exit 0
+          fi
+          echo '::notice::We created the following commits:'
+          git log --reverse -p "${BASE}"..
+
+          # Create Pull Request description
+          echo '### :rocket: Upgrades available' | tee upgrade.log
+          if [[ "${nb_upgrades}" -ge 1 ]]; then
+              echo '' | tee -a upgrade.log
+              echo '```' | tee -a upgrade.log
+              tee -a upgrade.log < upgrade_output.txt
+              echo '```' | tee -a upgrade.log
+          fi
+
+          echo '' | tee -a upgrade.log
+          echo ':warning: This Pull Request was automatically generated and should be carefully reviewed before acceptance. It may introduce **breaking changes**.' | tee -a upgrade.log
+
+          cat upgrade.log > "${GITHUB_STEP_SUMMARY}"
+          {
+            echo 'upgrade<<EOF';
+            cat upgrade.log;
+            echo 'EOF';
+          } >> "${GITHUB_OUTPUT}"
+
+          rm -f -- upgrade.log upgrade_output.txt list_packages.txt commit_msg.txt
+      - name: "Create Pull Request"
+        uses: "peter-evans/create-pull-request@v7"
+        with:
+          branch: "bump/cargo-upgrades"
+          title: "bump(cargo)!: :rocket: upgrades available"
+          labels: |
+            automated
+            dependencies
+          signoff: "true"
+          sign-commits: "true"
+          body: |
+            ${{ steps.upgrade.outputs.upgrade }}
+
+      - name: "Setup tmate session for debug"
+        if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        uses: "mxschmitt/action-tmate@v3"
+        timeout-minutes: 60
+        with:
+          limit-access-to-actor: true


### PR DESCRIPTION
Dependabot manages Go dependencies for the repository, but it's not currently set up to take care of Rust dependencies.

We could set up Dependabot to take care of Rust too, I think; here we simply reuse the workflow we have for the dataplane repository, because it's been working well for us.

This workflow does not contain all steps from the original one; in particular, we don't run `cargo deny check` before or after the updates, because cargo-deny has not been configured for this repository.

Link: https://github.com/githedgehog/dataplane/blob/2c28bbfcedf1/.github/workflows/bump.yml

**NOT TESTED** on this repo yet, but it works on `dataplane`, and shouldn't impact the rest of the code anyway if the workflow fails.

Next step (when we find the time): Consolidate with dataplane's workflow into a reusable GitHub Action.