### PR TITLE
ci(bump): Fix workflow to avoid using "just"

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -54,7 +54,7 @@ jobs:
           BASE="$(git rev-parse HEAD)"
 
           # Run "cargo update"
-          just cargo update
+          cargo update
           if ! git diff --quiet; then
               git add Cargo.lock
               git commit -sm "bump(cargo)!: bump dependencies (cargo update)"
@@ -62,7 +62,7 @@ jobs:
 
           # Check updates available with "cargo upgrade",
           # then bump each package individually through separate commits
-          just cargo upgrade --incompatible=allow --dry-run > upgrade_output.txt
+          cargo upgrade --incompatible=allow --dry-run > upgrade_output.txt
           sed '/^====/d; /^name .* new req$/d; s/ .*//' upgrade_output.txt > list_packages.txt
           nb_upgrades=$(wc -l < list_packages.txt)
 
@@ -72,7 +72,7 @@ jobs:
           while read -r package; do
               echo "bump(cargo)!: bump $package (cargo upgrade)" | tee commit_msg.txt
               echo '' | tee -a commit_msg.txt
-              just cargo upgrade --incompatible=allow --package "$package" | tee -a commit_msg.txt
+              cargo upgrade --incompatible=allow --package "$package" | tee -a commit_msg.txt
               git add Cargo.lock Cargo.toml
               git commit -sF commit_msg.txt
           done < list_packages.txt


### PR DESCRIPTION
Invoking "just" to run cargo command is a mistake, caused by importing the workflow description from the dataplane repository where we do use "just". Directly invoke cargo.
