### PR TITLE
chore: Bump patch release number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway_config"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.87.0"


### PR DESCRIPTION
No significant change in this new version. Turns out the workflow job to publish releases failed on the previous tag, so we're sending a new one to the press.
