### PR TITLE
ci: Make bump.yml run weekly rather than daily

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -12,9 +12,9 @@ on:
         required: false
         default: false
   schedule:
-    # Check for updates at 3:18 am every day
+    # Check for updates at 3:18 am every Monday
     # (Avoid midnight so we don't contribute to load spikes)
-    - cron: "18 3 * * *"
+    - cron: "18 3 * * 1"
 
 concurrency:
   group: "${{ github.workflow }}:${{ github.ref }}"


### PR DESCRIPTION
Change the workflow to have the scheduled execution run weekly rather than daily, because daily means to much fatigue due to PR reviews, and weekly sounds OK.

Early on Monday morning means we can look at it first thing in the week (bonus: we get the rest of the week to fix anything that breaks because of the upgrade!).
