### PR TITLE
Minimal tracing config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bolero",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway_config"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.87.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway_config"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.87.0"

--- a/pkg/dataplane/dataplane.pb.go
+++ b/pkg/dataplane/dataplane.pb.go
@@ -1958,69 +1958,17 @@ func (*Eal) Descriptor() ([]byte, []int) {
 	return file_proto_dataplane_proto_rawDescGZIP(), []int{25}
 }
 
-type TracingTagConfig struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Tag           string                 `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
-	Loglevel      LogLevel               `protobuf:"varint,2,opt,name=loglevel,proto3,enum=config.LogLevel" json:"loglevel,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *TracingTagConfig) Reset() {
-	*x = TracingTagConfig{}
-	mi := &file_proto_dataplane_proto_msgTypes[26]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *TracingTagConfig) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*TracingTagConfig) ProtoMessage() {}
-
-func (x *TracingTagConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_dataplane_proto_msgTypes[26]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use TracingTagConfig.ProtoReflect.Descriptor instead.
-func (*TracingTagConfig) Descriptor() ([]byte, []int) {
-	return file_proto_dataplane_proto_rawDescGZIP(), []int{26}
-}
-
-func (x *TracingTagConfig) GetTag() string {
-	if x != nil {
-		return x.Tag
-	}
-	return ""
-}
-
-func (x *TracingTagConfig) GetLoglevel() LogLevel {
-	if x != nil {
-		return x.Loglevel
-	}
-	return LogLevel_OFF
-}
-
 type TracingConfig struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Default       LogLevel               `protobuf:"varint,1,opt,name=default,proto3,enum=config.LogLevel" json:"default,omitempty"`
-	Tagconfig     []*TracingTagConfig    `protobuf:"bytes,2,rep,name=tagconfig,proto3" json:"tagconfig,omitempty"`
+	Taglevel      map[string]LogLevel    `protobuf:"bytes,2,rep,name=taglevel,proto3" json:"taglevel,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value,enum=config.LogLevel"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TracingConfig) Reset() {
 	*x = TracingConfig{}
-	mi := &file_proto_dataplane_proto_msgTypes[27]
+	mi := &file_proto_dataplane_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2032,7 +1980,7 @@ func (x *TracingConfig) String() string {
 func (*TracingConfig) ProtoMessage() {}
 
 func (x *TracingConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_dataplane_proto_msgTypes[27]
+	mi := &file_proto_dataplane_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2045,7 +1993,7 @@ func (x *TracingConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracingConfig.ProtoReflect.Descriptor instead.
 func (*TracingConfig) Descriptor() ([]byte, []int) {
-	return file_proto_dataplane_proto_rawDescGZIP(), []int{27}
+	return file_proto_dataplane_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TracingConfig) GetDefault() LogLevel {
@@ -2055,9 +2003,9 @@ func (x *TracingConfig) GetDefault() LogLevel {
 	return LogLevel_OFF
 }
 
-func (x *TracingConfig) GetTagconfig() []*TracingTagConfig {
+func (x *TracingConfig) GetTaglevel() map[string]LogLevel {
 	if x != nil {
-		return x.Tagconfig
+		return x.Taglevel
 	}
 	return nil
 }
@@ -2076,7 +2024,7 @@ type Device struct {
 
 func (x *Device) Reset() {
 	*x = Device{}
-	mi := &file_proto_dataplane_proto_msgTypes[28]
+	mi := &file_proto_dataplane_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2088,7 +2036,7 @@ func (x *Device) String() string {
 func (*Device) ProtoMessage() {}
 
 func (x *Device) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_dataplane_proto_msgTypes[28]
+	mi := &file_proto_dataplane_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2101,7 +2049,7 @@ func (x *Device) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Device.ProtoReflect.Descriptor instead.
 func (*Device) Descriptor() ([]byte, []int) {
-	return file_proto_dataplane_proto_rawDescGZIP(), []int{28}
+	return file_proto_dataplane_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Device) GetDriver() PacketDriver {
@@ -2152,7 +2100,7 @@ type GatewayConfig struct {
 
 func (x *GatewayConfig) Reset() {
 	*x = GatewayConfig{}
-	mi := &file_proto_dataplane_proto_msgTypes[29]
+	mi := &file_proto_dataplane_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2164,7 +2112,7 @@ func (x *GatewayConfig) String() string {
 func (*GatewayConfig) ProtoMessage() {}
 
 func (x *GatewayConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_dataplane_proto_msgTypes[29]
+	mi := &file_proto_dataplane_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2177,7 +2125,7 @@ func (x *GatewayConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GatewayConfig.ProtoReflect.Descriptor instead.
 func (*GatewayConfig) Descriptor() ([]byte, []int) {
-	return file_proto_dataplane_proto_rawDescGZIP(), []int{29}
+	return file_proto_dataplane_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GatewayConfig) GetGeneration() int64 {
@@ -2336,13 +2284,13 @@ const file_proto_dataplane_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
 	"\vsystem_name\x18\x02 \x01(\tR\n" +
 	"systemName\"\x05\n" +
-	"\x03Eal\"R\n" +
-	"\x10TracingTagConfig\x12\x10\n" +
-	"\x03tag\x18\x01 \x01(\tR\x03tag\x12,\n" +
-	"\bloglevel\x18\x02 \x01(\x0e2\x10.config.LogLevelR\bloglevel\"s\n" +
+	"\x03Eal\"\xcb\x01\n" +
 	"\rTracingConfig\x12*\n" +
-	"\adefault\x18\x01 \x01(\x0e2\x10.config.LogLevelR\adefault\x126\n" +
-	"\ttagconfig\x18\x02 \x03(\v2\x18.config.TracingTagConfigR\ttagconfig\"\xc7\x01\n" +
+	"\adefault\x18\x01 \x01(\x0e2\x10.config.LogLevelR\adefault\x12?\n" +
+	"\btaglevel\x18\x02 \x03(\v2#.config.TracingConfig.TaglevelEntryR\btaglevel\x1aM\n" +
+	"\rTaglevelEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12&\n" +
+	"\x05value\x18\x02 \x01(\x0e2\x10.config.LogLevelR\x05value:\x028\x01\"\xc7\x01\n" +
 	"\x06Device\x12,\n" +
 	"\x06driver\x18\x01 \x01(\x0e2\x14.config.PacketDriverR\x06driver\x12\x1d\n" +
 	"\x03eal\x18\x02 \x01(\v2\v.config.EalR\x03eal\x12#\n" +
@@ -2444,13 +2392,13 @@ var file_proto_dataplane_proto_goTypes = []any{
 	(*Underlay)(nil),                    // 30: config.Underlay
 	(*Ports)(nil),                       // 31: config.Ports
 	(*Eal)(nil),                         // 32: config.Eal
-	(*TracingTagConfig)(nil),            // 33: config.TracingTagConfig
-	(*TracingConfig)(nil),               // 34: config.TracingConfig
-	(*Device)(nil),                      // 35: config.Device
-	(*GatewayConfig)(nil),               // 36: config.GatewayConfig
+	(*TracingConfig)(nil),               // 33: config.TracingConfig
+	(*Device)(nil),                      // 34: config.Device
+	(*GatewayConfig)(nil),               // 35: config.GatewayConfig
+	nil,                                 // 36: config.TracingConfig.TaglevelEntry
 }
 var file_proto_dataplane_proto_depIdxs = []int32{
-	36, // 0: config.UpdateConfigRequest.config:type_name -> config.GatewayConfig
+	35, // 0: config.UpdateConfigRequest.config:type_name -> config.GatewayConfig
 	0,  // 1: config.UpdateConfigResponse.error:type_name -> config.Error
 	1,  // 2: config.OspfInterface.network_type:type_name -> config.OspfNetworkType
 	2,  // 3: config.Interface.type:type_name -> config.IfType
@@ -2474,20 +2422,20 @@ var file_proto_dataplane_proto_depIdxs = []int32{
 	28, // 21: config.VRF.router:type_name -> config.RouterConfig
 	13, // 22: config.VRF.ospf:type_name -> config.OspfConfig
 	29, // 23: config.Underlay.vrfs:type_name -> config.VRF
-	5,  // 24: config.TracingTagConfig.loglevel:type_name -> config.LogLevel
-	5,  // 25: config.TracingConfig.default:type_name -> config.LogLevel
-	33, // 26: config.TracingConfig.tagconfig:type_name -> config.TracingTagConfig
-	6,  // 27: config.Device.driver:type_name -> config.PacketDriver
-	32, // 28: config.Device.eal:type_name -> config.Eal
-	31, // 29: config.Device.ports:type_name -> config.Ports
-	34, // 30: config.Device.tracing:type_name -> config.TracingConfig
-	35, // 31: config.GatewayConfig.device:type_name -> config.Device
-	30, // 32: config.GatewayConfig.underlay:type_name -> config.Underlay
-	21, // 33: config.GatewayConfig.overlay:type_name -> config.Overlay
+	5,  // 24: config.TracingConfig.default:type_name -> config.LogLevel
+	36, // 25: config.TracingConfig.taglevel:type_name -> config.TracingConfig.TaglevelEntry
+	6,  // 26: config.Device.driver:type_name -> config.PacketDriver
+	32, // 27: config.Device.eal:type_name -> config.Eal
+	31, // 28: config.Device.ports:type_name -> config.Ports
+	33, // 29: config.Device.tracing:type_name -> config.TracingConfig
+	34, // 30: config.GatewayConfig.device:type_name -> config.Device
+	30, // 31: config.GatewayConfig.underlay:type_name -> config.Underlay
+	21, // 32: config.GatewayConfig.overlay:type_name -> config.Overlay
+	5,  // 33: config.TracingConfig.TaglevelEntry.value:type_name -> config.LogLevel
 	7,  // 34: config.ConfigService.GetConfig:input_type -> config.GetConfigRequest
 	10, // 35: config.ConfigService.GetConfigGeneration:input_type -> config.GetConfigGenerationRequest
 	8,  // 36: config.ConfigService.UpdateConfig:input_type -> config.UpdateConfigRequest
-	36, // 37: config.ConfigService.GetConfig:output_type -> config.GatewayConfig
+	35, // 37: config.ConfigService.GetConfig:output_type -> config.GatewayConfig
 	11, // 38: config.ConfigService.GetConfigGeneration:output_type -> config.GetConfigGenerationResponse
 	9,  // 39: config.ConfigService.UpdateConfig:output_type -> config.UpdateConfigResponse
 	37, // [37:40] is the sub-list for method output_type

--- a/pkg/dataplane/dataplane.pb.go
+++ b/pkg/dataplane/dataplane.pb.go
@@ -283,28 +283,31 @@ func (BgpAF) EnumDescriptor() ([]byte, []int) {
 type LogLevel int32
 
 const (
-	LogLevel_ERROR   LogLevel = 0
-	LogLevel_WARNING LogLevel = 1
-	LogLevel_INFO    LogLevel = 2
-	LogLevel_DEBUG   LogLevel = 3
-	LogLevel_TRACE   LogLevel = 4
+	LogLevel_OFF     LogLevel = 0
+	LogLevel_ERROR   LogLevel = 1
+	LogLevel_WARNING LogLevel = 2
+	LogLevel_INFO    LogLevel = 3
+	LogLevel_DEBUG   LogLevel = 4
+	LogLevel_TRACE   LogLevel = 5
 )
 
 // Enum value maps for LogLevel.
 var (
 	LogLevel_name = map[int32]string{
-		0: "ERROR",
-		1: "WARNING",
-		2: "INFO",
-		3: "DEBUG",
-		4: "TRACE",
+		0: "OFF",
+		1: "ERROR",
+		2: "WARNING",
+		3: "INFO",
+		4: "DEBUG",
+		5: "TRACE",
 	}
 	LogLevel_value = map[string]int32{
-		"ERROR":   0,
-		"WARNING": 1,
-		"INFO":    2,
-		"DEBUG":   3,
-		"TRACE":   4,
+		"OFF":     0,
+		"ERROR":   1,
+		"WARNING": 2,
+		"INFO":    3,
+		"DEBUG":   4,
+		"TRACE":   5,
 	}
 )
 
@@ -1955,6 +1958,110 @@ func (*Eal) Descriptor() ([]byte, []int) {
 	return file_proto_dataplane_proto_rawDescGZIP(), []int{25}
 }
 
+type TracingTagConfig struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Tag           string                 `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	Loglevel      LogLevel               `protobuf:"varint,2,opt,name=loglevel,proto3,enum=config.LogLevel" json:"loglevel,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TracingTagConfig) Reset() {
+	*x = TracingTagConfig{}
+	mi := &file_proto_dataplane_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TracingTagConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TracingTagConfig) ProtoMessage() {}
+
+func (x *TracingTagConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_dataplane_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TracingTagConfig.ProtoReflect.Descriptor instead.
+func (*TracingTagConfig) Descriptor() ([]byte, []int) {
+	return file_proto_dataplane_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *TracingTagConfig) GetTag() string {
+	if x != nil {
+		return x.Tag
+	}
+	return ""
+}
+
+func (x *TracingTagConfig) GetLoglevel() LogLevel {
+	if x != nil {
+		return x.Loglevel
+	}
+	return LogLevel_OFF
+}
+
+type TracingConfig struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Default       LogLevel               `protobuf:"varint,1,opt,name=default,proto3,enum=config.LogLevel" json:"default,omitempty"`
+	Tagconfig     []*TracingTagConfig    `protobuf:"bytes,2,rep,name=tagconfig,proto3" json:"tagconfig,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TracingConfig) Reset() {
+	*x = TracingConfig{}
+	mi := &file_proto_dataplane_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TracingConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TracingConfig) ProtoMessage() {}
+
+func (x *TracingConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_dataplane_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TracingConfig.ProtoReflect.Descriptor instead.
+func (*TracingConfig) Descriptor() ([]byte, []int) {
+	return file_proto_dataplane_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *TracingConfig) GetDefault() LogLevel {
+	if x != nil {
+		return x.Default
+	}
+	return LogLevel_OFF
+}
+
+func (x *TracingConfig) GetTagconfig() []*TracingTagConfig {
+	if x != nil {
+		return x.Tagconfig
+	}
+	return nil
+}
+
 // System level config options
 type Device struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1962,14 +2069,14 @@ type Device struct {
 	Eal           *Eal                   `protobuf:"bytes,2,opt,name=eal,proto3" json:"eal,omitempty"`
 	Ports         []*Ports               `protobuf:"bytes,3,rep,name=ports,proto3" json:"ports,omitempty"`
 	Hostname      string                 `protobuf:"bytes,4,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	Loglevel      LogLevel               `protobuf:"varint,5,opt,name=loglevel,proto3,enum=config.LogLevel" json:"loglevel,omitempty"`
+	Tracing       *TracingConfig         `protobuf:"bytes,5,opt,name=tracing,proto3" json:"tracing,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Device) Reset() {
 	*x = Device{}
-	mi := &file_proto_dataplane_proto_msgTypes[26]
+	mi := &file_proto_dataplane_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1981,7 +2088,7 @@ func (x *Device) String() string {
 func (*Device) ProtoMessage() {}
 
 func (x *Device) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_dataplane_proto_msgTypes[26]
+	mi := &file_proto_dataplane_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1994,7 +2101,7 @@ func (x *Device) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Device.ProtoReflect.Descriptor instead.
 func (*Device) Descriptor() ([]byte, []int) {
-	return file_proto_dataplane_proto_rawDescGZIP(), []int{26}
+	return file_proto_dataplane_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *Device) GetDriver() PacketDriver {
@@ -2025,11 +2132,11 @@ func (x *Device) GetHostname() string {
 	return ""
 }
 
-func (x *Device) GetLoglevel() LogLevel {
+func (x *Device) GetTracing() *TracingConfig {
 	if x != nil {
-		return x.Loglevel
+		return x.Tracing
 	}
-	return LogLevel_ERROR
+	return nil
 }
 
 // Complete Gateway config options
@@ -2045,7 +2152,7 @@ type GatewayConfig struct {
 
 func (x *GatewayConfig) Reset() {
 	*x = GatewayConfig{}
-	mi := &file_proto_dataplane_proto_msgTypes[27]
+	mi := &file_proto_dataplane_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2057,7 +2164,7 @@ func (x *GatewayConfig) String() string {
 func (*GatewayConfig) ProtoMessage() {}
 
 func (x *GatewayConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_dataplane_proto_msgTypes[27]
+	mi := &file_proto_dataplane_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2070,7 +2177,7 @@ func (x *GatewayConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GatewayConfig.ProtoReflect.Descriptor instead.
 func (*GatewayConfig) Descriptor() ([]byte, []int) {
-	return file_proto_dataplane_proto_rawDescGZIP(), []int{27}
+	return file_proto_dataplane_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GatewayConfig) GetGeneration() int64 {
@@ -2229,13 +2336,19 @@ const file_proto_dataplane_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
 	"\vsystem_name\x18\x02 \x01(\tR\n" +
 	"systemName\"\x05\n" +
-	"\x03Eal\"\xc4\x01\n" +
+	"\x03Eal\"R\n" +
+	"\x10TracingTagConfig\x12\x10\n" +
+	"\x03tag\x18\x01 \x01(\tR\x03tag\x12,\n" +
+	"\bloglevel\x18\x02 \x01(\x0e2\x10.config.LogLevelR\bloglevel\"s\n" +
+	"\rTracingConfig\x12*\n" +
+	"\adefault\x18\x01 \x01(\x0e2\x10.config.LogLevelR\adefault\x126\n" +
+	"\ttagconfig\x18\x02 \x03(\v2\x18.config.TracingTagConfigR\ttagconfig\"\xc7\x01\n" +
 	"\x06Device\x12,\n" +
 	"\x06driver\x18\x01 \x01(\x0e2\x14.config.PacketDriverR\x06driver\x12\x1d\n" +
 	"\x03eal\x18\x02 \x01(\v2\v.config.EalR\x03eal\x12#\n" +
 	"\x05ports\x18\x03 \x03(\v2\r.config.PortsR\x05ports\x12\x1a\n" +
-	"\bhostname\x18\x04 \x01(\tR\bhostname\x12,\n" +
-	"\bloglevel\x18\x05 \x01(\x0e2\x10.config.LogLevelR\bloglevel\"\xb0\x01\n" +
+	"\bhostname\x18\x04 \x01(\tR\bhostname\x12/\n" +
+	"\atracing\x18\x05 \x01(\v2\x15.config.TracingConfigR\atracing\"\xb0\x01\n" +
 	"\rGatewayConfig\x12\x1e\n" +
 	"\n" +
 	"generation\x18\x01 \x01(\x03R\n" +
@@ -2266,13 +2379,14 @@ const file_proto_dataplane_proto_rawDesc = "" +
 	"\fIPV4_UNICAST\x10\x00\x12\x10\n" +
 	"\fIPV6_UNICAST\x10\x01\x12\x0e\n" +
 	"\n" +
-	"L2VPN_EVPN\x10\x02*B\n" +
-	"\bLogLevel\x12\t\n" +
-	"\x05ERROR\x10\x00\x12\v\n" +
-	"\aWARNING\x10\x01\x12\b\n" +
-	"\x04INFO\x10\x02\x12\t\n" +
-	"\x05DEBUG\x10\x03\x12\t\n" +
-	"\x05TRACE\x10\x04*$\n" +
+	"L2VPN_EVPN\x10\x02*K\n" +
+	"\bLogLevel\x12\a\n" +
+	"\x03OFF\x10\x00\x12\t\n" +
+	"\x05ERROR\x10\x01\x12\v\n" +
+	"\aWARNING\x10\x02\x12\b\n" +
+	"\x04INFO\x10\x03\x12\t\n" +
+	"\x05DEBUG\x10\x04\x12\t\n" +
+	"\x05TRACE\x10\x05*$\n" +
 	"\fPacketDriver\x12\n" +
 	"\n" +
 	"\x06KERNEL\x10\x00\x12\b\n" +
@@ -2295,7 +2409,7 @@ func file_proto_dataplane_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_dataplane_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_proto_dataplane_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_proto_dataplane_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_proto_dataplane_proto_goTypes = []any{
 	(Error)(0),                          // 0: config.Error
 	(OspfNetworkType)(0),                // 1: config.OspfNetworkType
@@ -2330,11 +2444,13 @@ var file_proto_dataplane_proto_goTypes = []any{
 	(*Underlay)(nil),                    // 30: config.Underlay
 	(*Ports)(nil),                       // 31: config.Ports
 	(*Eal)(nil),                         // 32: config.Eal
-	(*Device)(nil),                      // 33: config.Device
-	(*GatewayConfig)(nil),               // 34: config.GatewayConfig
+	(*TracingTagConfig)(nil),            // 33: config.TracingTagConfig
+	(*TracingConfig)(nil),               // 34: config.TracingConfig
+	(*Device)(nil),                      // 35: config.Device
+	(*GatewayConfig)(nil),               // 36: config.GatewayConfig
 }
 var file_proto_dataplane_proto_depIdxs = []int32{
-	34, // 0: config.UpdateConfigRequest.config:type_name -> config.GatewayConfig
+	36, // 0: config.UpdateConfigRequest.config:type_name -> config.GatewayConfig
 	0,  // 1: config.UpdateConfigResponse.error:type_name -> config.Error
 	1,  // 2: config.OspfInterface.network_type:type_name -> config.OspfNetworkType
 	2,  // 3: config.Interface.type:type_name -> config.IfType
@@ -2358,24 +2474,27 @@ var file_proto_dataplane_proto_depIdxs = []int32{
 	28, // 21: config.VRF.router:type_name -> config.RouterConfig
 	13, // 22: config.VRF.ospf:type_name -> config.OspfConfig
 	29, // 23: config.Underlay.vrfs:type_name -> config.VRF
-	6,  // 24: config.Device.driver:type_name -> config.PacketDriver
-	32, // 25: config.Device.eal:type_name -> config.Eal
-	31, // 26: config.Device.ports:type_name -> config.Ports
-	5,  // 27: config.Device.loglevel:type_name -> config.LogLevel
-	33, // 28: config.GatewayConfig.device:type_name -> config.Device
-	30, // 29: config.GatewayConfig.underlay:type_name -> config.Underlay
-	21, // 30: config.GatewayConfig.overlay:type_name -> config.Overlay
-	7,  // 31: config.ConfigService.GetConfig:input_type -> config.GetConfigRequest
-	10, // 32: config.ConfigService.GetConfigGeneration:input_type -> config.GetConfigGenerationRequest
-	8,  // 33: config.ConfigService.UpdateConfig:input_type -> config.UpdateConfigRequest
-	34, // 34: config.ConfigService.GetConfig:output_type -> config.GatewayConfig
-	11, // 35: config.ConfigService.GetConfigGeneration:output_type -> config.GetConfigGenerationResponse
-	9,  // 36: config.ConfigService.UpdateConfig:output_type -> config.UpdateConfigResponse
-	34, // [34:37] is the sub-list for method output_type
-	31, // [31:34] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	5,  // 24: config.TracingTagConfig.loglevel:type_name -> config.LogLevel
+	5,  // 25: config.TracingConfig.default:type_name -> config.LogLevel
+	33, // 26: config.TracingConfig.tagconfig:type_name -> config.TracingTagConfig
+	6,  // 27: config.Device.driver:type_name -> config.PacketDriver
+	32, // 28: config.Device.eal:type_name -> config.Eal
+	31, // 29: config.Device.ports:type_name -> config.Ports
+	34, // 30: config.Device.tracing:type_name -> config.TracingConfig
+	35, // 31: config.GatewayConfig.device:type_name -> config.Device
+	30, // 32: config.GatewayConfig.underlay:type_name -> config.Underlay
+	21, // 33: config.GatewayConfig.overlay:type_name -> config.Overlay
+	7,  // 34: config.ConfigService.GetConfig:input_type -> config.GetConfigRequest
+	10, // 35: config.ConfigService.GetConfigGeneration:input_type -> config.GetConfigGenerationRequest
+	8,  // 36: config.ConfigService.UpdateConfig:input_type -> config.UpdateConfigRequest
+	36, // 37: config.ConfigService.GetConfig:output_type -> config.GatewayConfig
+	11, // 38: config.ConfigService.GetConfigGeneration:output_type -> config.GetConfigGenerationResponse
+	9,  // 39: config.ConfigService.UpdateConfig:output_type -> config.UpdateConfigResponse
+	37, // [37:40] is the sub-list for method output_type
+	34, // [34:37] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_proto_dataplane_proto_init() }
@@ -2406,7 +2525,7 @@ func file_proto_dataplane_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_dataplane_proto_rawDesc), len(file_proto_dataplane_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   28,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/dataplane.proto
+++ b/proto/dataplane.proto
@@ -247,11 +247,21 @@ message Eal {
 
 /* Log-level for dataplane and DPDK */
 enum LogLevel {
-  ERROR = 0;
-  WARNING = 1;
-  INFO = 2;
-  DEBUG = 3;
-  TRACE = 4;
+  OFF = 0;
+  ERROR = 1;
+  WARNING = 2;
+  INFO = 3;
+  DEBUG = 4;
+  TRACE = 5;
+}
+
+message TracingTagConfig {
+  string tag = 1;
+  LogLevel loglevel = 2;
+}
+message TracingConfig {
+  LogLevel default = 1;
+  repeated TracingTagConfig tagconfig = 2;
 }
 
 /* Backend driver for packet processing */
@@ -266,7 +276,7 @@ message Device {
   Eal eal = 2;
   repeated Ports ports = 3;
   string hostname = 4;
-  LogLevel loglevel = 5;
+  TracingConfig tracing = 5;
 }
 
 /* ================ */

--- a/proto/dataplane.proto
+++ b/proto/dataplane.proto
@@ -255,13 +255,9 @@ enum LogLevel {
   TRACE = 5;
 }
 
-message TracingTagConfig {
-  string tag = 1;
-  LogLevel loglevel = 2;
-}
 message TracingConfig {
   LogLevel default = 1;
-  repeated TracingTagConfig tagconfig = 2;
+  map<string, LogLevel> taglevel = 2;
 }
 
 /* Backend driver for packet processing */

--- a/src/bolero/device.rs
+++ b/src/bolero/device.rs
@@ -2,8 +2,19 @@
 // Copyright 2025 Hedgehog
 
 use crate::bolero::support::K8sObjectNameString;
-use crate::config::{Device, LogLevel, PacketDriver};
+use crate::config::{Device, PacketDriver, TracingConfig};
+
 use bolero::{Driver, TypeGenerator};
+
+impl TypeGenerator for TracingConfig {
+    fn generate<D: Driver>(_d: &mut D) -> Option<Self> {
+        // empty
+        Some(TracingConfig {
+            default: 1,
+            tagconfig: vec![],
+        })
+    }
+}
 
 impl TypeGenerator for Device {
     fn generate<D: Driver>(d: &mut D) -> Option<Self> {
@@ -12,7 +23,7 @@ impl TypeGenerator for Device {
             eal: None,     // TODO Add support for EAL when dataplane supports it
             ports: vec![], // TODO Add support for ports when dataplane supports it
             hostname: d.produce::<K8sObjectNameString>()?.0,
-            loglevel: i32::from(d.produce::<LogLevel>()?),
+            tracing: Some(d.produce::<TracingConfig>()?),
         })
     }
 }

--- a/src/generated/config.rs
+++ b/src/generated/config.rs
@@ -301,20 +301,12 @@ pub struct Ports {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Eal {}
 #[derive(::serde::Deserialize, ::serde::Serialize)]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct TracingTagConfig {
-    #[prost(string, tag = "1")]
-    pub tag: ::prost::alloc::string::String,
-    #[prost(enumeration = "LogLevel", tag = "2")]
-    pub loglevel: i32,
-}
-#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TracingConfig {
     #[prost(enumeration = "LogLevel", tag = "1")]
     pub default: i32,
-    #[prost(message, repeated, tag = "2")]
-    pub tagconfig: ::prost::alloc::vec::Vec<TracingTagConfig>,
+    #[prost(map = "string, enumeration(LogLevel)", tag = "2")]
+    pub taglevel: ::std::collections::HashMap<::prost::alloc::string::String, i32>,
 }
 /// System level config options
 #[derive(::serde::Deserialize, ::serde::Serialize)]

--- a/src/generated/config.rs
+++ b/src/generated/config.rs
@@ -300,6 +300,22 @@ pub struct Ports {
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Eal {}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct TracingTagConfig {
+    #[prost(string, tag = "1")]
+    pub tag: ::prost::alloc::string::String,
+    #[prost(enumeration = "LogLevel", tag = "2")]
+    pub loglevel: i32,
+}
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TracingConfig {
+    #[prost(enumeration = "LogLevel", tag = "1")]
+    pub default: i32,
+    #[prost(message, repeated, tag = "2")]
+    pub tagconfig: ::prost::alloc::vec::Vec<TracingTagConfig>,
+}
 /// System level config options
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -312,8 +328,8 @@ pub struct Device {
     pub ports: ::prost::alloc::vec::Vec<Ports>,
     #[prost(string, tag = "4")]
     pub hostname: ::prost::alloc::string::String,
-    #[prost(enumeration = "LogLevel", tag = "5")]
-    pub loglevel: i32,
+    #[prost(message, optional, tag = "5")]
+    pub tracing: ::core::option::Option<TracingConfig>,
 }
 /// Complete Gateway config options
 #[derive(::serde::Deserialize, ::serde::Serialize)]
@@ -498,11 +514,12 @@ impl BgpAf {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum LogLevel {
-    Error = 0,
-    Warning = 1,
-    Info = 2,
-    Debug = 3,
-    Trace = 4,
+    Off = 0,
+    Error = 1,
+    Warning = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
 }
 impl LogLevel {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -511,6 +528,7 @@ impl LogLevel {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
+            Self::Off => "OFF",
             Self::Error => "ERROR",
             Self::Warning => "WARNING",
             Self::Info => "INFO",
@@ -521,6 +539,7 @@ impl LogLevel {
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
+            "OFF" => Some(Self::Off),
             "ERROR" => Some(Self::Error),
             "WARNING" => Some(Self::Warning),
             "INFO" => Some(Self::Info),


### PR DESCRIPTION
Adds minimal tracing config and adds OFF to loglevel. The latter might be a breaking change in dataplane builds/tests or conversions. However, I don't think we were using the loglevel at all.